### PR TITLE
register placementrule reconciler when its CRD is installed.

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,17 +132,6 @@ func main() {
 			os.Exit(1)
 		}
 	}
-
-	if err = (&prctrl.PlacementRuleReconciler{
-		Client:     mgr.GetClient(),
-		Log:        ctrl.Log.WithName("controllers").WithName("PlacementRule"),
-		Scheme:     mgr.GetScheme(),
-		APIReader:  mgr.GetAPIReader(),
-		RESTMapper: mgr.GetRESTMapper(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "PlacementRule")
-		os.Exit(1)
-	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {


### PR DESCRIPTION
A fix for: https://github.com/open-cluster-management/multicluster-observability-operator/pull/400

Only register placementrule reconciler when its CRD is installed.