### PR TITLE
Remove KubeAPIServerLatency alert, improve grafana dashboard performance

### DIFF
--- a/manifests/base/alertmanager/alert_rules.yaml
+++ b/manifests/base/alertmanager/alert_rules.yaml
@@ -5,19 +5,6 @@ metadata:
 data:
   default_rules.yaml: |
     groups:
-      - name: control-plane-health
-        rules:
-        - alert: KubeAPIServerLatency
-          annotations:
-            summary: Fires when Kube API Server 99th percentile latency exceeds the threshold.
-            description: "The Kube API Server has a high 99th percentile Latency: {{ $value }} seconds for cluster: {{ $labels.cluster }} clusterid: {{ $labels.clusterID }}."  
-          expr: |
-            max(histogram_quantile(0.99,sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver", verb!="WATCH"}[5m])) by (verb,le,cluster,clusterID))) by (cluster,clusterID) >1
-          for: 3m
-          labels:
-            cluster: "{{ $labels.cluster }}"
-            clusterID: "{{ $labels.clusterID }}"
-            severity: critical
       - name: kubernetes-storage
         rules:
         - alert: KubePersistentVolumeFillingUp

--- a/manifests/base/grafana/acm-multicluster-dash.yaml
+++ b/manifests/base/grafana/acm-multicluster-dash.yaml
@@ -141,7 +141,7 @@ data:
           ],
           "targets": [
             {
-              "expr": "max(histogram_quantile(0.99,sum(rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\", verb!=\"WATCH\"}[5m])) by (verb,le,cluster))) by (cluster)",
+              "expr": "max(histogram_quantile(0.99,sum(rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\", verb!=\"WATCH\"}[5m])) by (le,cluster))) by (cluster)",
               "format": "table",
               "instant": true,
               "refId": "A"


### PR DESCRIPTION
Related: open-cluster-management/backlog#10693

Remove expensive alerting rule KubeAPIServerLatency as it is a memory hog and is preventing our ability to scale
Do not group by verb in the Grafana query for APIServer control plane health. This Improves Grafana "ACM Cluster Overview" page load performance.