### PR TITLE
fix base image not found issue.

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/open-cluster-management/builder:go1.15-linux AS builder
+FROM registry.ci.openshift.org/open-cluster-management/builder:go1.15-linux-amd64 AS builder
 
 
 WORKDIR /workspace


### PR DESCRIPTION
Fix prow build issue:

```
INFO[2021-04-09T07:41:53Z] ci-operator version v20210408-34d4be8        
INFO[2021-04-09T07:41:53Z] Loading configuration from https://config.ci.openshift.org for open-cluster-management/multicluster-observability-operator@main 
INFO[2021-04-09T07:41:53Z] Resolved source https://github.com/open-cluster-management/multicluster-observability-operator to main@0d69e8d2, merging: #445 a42b5a64 @morvencao 
INFO[2021-04-09T07:41:53Z] Ran for 0s                                   
ERRO[2021-04-09T07:41:53Z] Some steps failed:                           
ERRO[2021-04-09T07:41:53Z]   * could not resolve inputs: could not determine inputs for step [input:open-cluster-management_builder_go1.15-linux]: could not resolve base image: imagestreamtags.image.openshift.io "builder:go1.15-linux" not found 
```

revert: https://github.com/open-cluster-management/multicluster-observability-operator/pull/449