### PR TITLE
use only one manifestwork in observability

### DIFF
--- a/controllers/placementrule/manifestwork_test.go
+++ b/controllers/placementrule/manifestwork_test.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	pullSecretName   = "test-pull-secret"
-	operatorWorkSize = 6
-	resourceWorkSize = 5
+	pullSecretName = "test-pull-secret"
+	workSize       = 11
 )
 
 func newTestMCO() *mcov1beta2.MultiClusterObservability {
@@ -129,20 +128,12 @@ func TestManifestWork(t *testing.T) {
 		t.Fatalf("Failed to create manifestworks: (%v)", err)
 	}
 	found := &workv1.ManifestWork{}
-	workName := namespace + operatorWorkNameSuffix
+	workName := namespace + workNameSuffix
 	err = c.Get(context.TODO(), types.NamespacedName{Name: workName, Namespace: namespace}, found)
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork %s: (%v)", workName, err)
 	}
-	if len(found.Spec.Workload.Manifests) != operatorWorkSize {
-		t.Fatalf("Wrong size of manifests in the mainfestwork %s", workName)
-	}
-	workName = namespace + resWorkNameSuffix
-	err = c.Get(context.TODO(), types.NamespacedName{Name: workName, Namespace: namespace}, found)
-	if err != nil {
-		t.Fatalf("Failed to get manifestwork %s: (%v)", workName, err)
-	}
-	if len(found.Spec.Workload.Manifests) != resourceWorkSize {
+	if len(found.Spec.Workload.Manifests) != workSize {
 		t.Fatalf("Wrong size of manifests in the mainfestwork %s", workName)
 	}
 
@@ -154,7 +145,7 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork %s: (%v)", workName, err)
 	}
-	if len(found.Spec.Workload.Manifests) != resourceWorkSize-1 {
+	if len(found.Spec.Workload.Manifests) != workSize-1 {
 		t.Fatalf("Wrong size of manifests in the mainfestwork %s", workName)
 	}
 
@@ -168,11 +159,7 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to delete manifestworks: (%v)", err)
 	}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + operatorWorkNameSuffix, Namespace: namespace}, found)
-	if err == nil || !errors.IsNotFound(err) {
-		t.Fatalf("Manifestwork not deleted: (%v)", err)
-	}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + resWorkNameSuffix, Namespace: namespace}, found)
+	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, found)
 	if err == nil || !errors.IsNotFound(err) {
 		t.Fatalf("Manifestwork not deleted: (%v)", err)
 	}

--- a/controllers/placementrule/placementrule_controller.go
+++ b/controllers/placementrule/placementrule_controller.go
@@ -161,8 +161,7 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		staleAddons = append(staleAddons, addon.Namespace)
 	}
 	for _, work := range workList.Items {
-		if work.Name != work.Namespace+operatorWorkNameSuffix &&
-			work.Name != work.Namespace+resWorkNameSuffix {
+		if work.Name != work.Namespace+workNameSuffix {
 			reqLogger.Info("To delete invalid manifestwork", "name", work.Name, "namespace", work.Namespace)
 			err = deleteManifestWork(r.Client, work.Name, work.Namespace)
 			if err != nil {

--- a/controllers/placementrule/placementrule_controller_test.go
+++ b/controllers/placementrule/placementrule_controller_test.go
@@ -117,11 +117,11 @@ func TestObservabilityAddonController(t *testing.T) {
 		t.Fatalf("reconcile: (%v)", err)
 	}
 	found := &workv1.ManifestWork{}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + resWorkNameSuffix, Namespace: namespace}, found)
+	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, found)
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork for cluster1: (%v)", err)
 	}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace2 + resWorkNameSuffix, Namespace: namespace2}, found)
+	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace2 + workNameSuffix, Namespace: namespace2}, found)
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork for cluster2: (%v)", err)
 	}
@@ -153,11 +153,11 @@ func TestObservabilityAddonController(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + resWorkNameSuffix, Namespace: namespace}, found)
+	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, found)
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork for cluster1: (%v)", err)
 	}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace2 + resWorkNameSuffix, Namespace: namespace2}, found)
+	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace2 + workNameSuffix, Namespace: namespace2}, found)
 	if err == nil || !errors.IsNotFound(err) {
 		t.Fatalf("Failed to delete manifestwork for cluster2: (%v)", err)
 	}
@@ -198,7 +198,7 @@ func TestObservabilityAddonController(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + resWorkNameSuffix, Namespace: namespace}, found)
+	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, found)
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork for cluster1: (%v)", err)
 	}


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11704

Signed-off-by: Marco <llan@redhat.com>