### PR TITLE
Update replicationFactor to 3

### DIFF
--- a/controllers/multiclusterobservability/observatorium.go
+++ b/controllers/multiclusterobservability/observatorium.go
@@ -321,7 +321,12 @@ func newReceiversSpec(
 	receSpec := obsv1alpha1.ReceiversSpec{}
 	receSpec.Retention = mco.Spec.RetentionConfig.RetentionInLocal
 	receSpec.Replicas = mcoconfig.GetObservabilityComponentReplicas(mcoconfig.ThanosReceive)
-	receSpec.ReplicationFactor = &config.Replicas3
+	if *receSpec.Replicas < 3 {
+		receSpec.ReplicationFactor = receSpec.Replicas
+	} else {
+		receSpec.ReplicationFactor = &config.Replicas3
+	}
+
 	receSpec.ServiceMonitor = true
 	if !mcoconfig.WithoutResourcesRequests(mco.GetAnnotations()) {
 		receSpec.Resources = mco.Spec.Resources.ThanosReceive

--- a/controllers/multiclusterobservability/observatorium.go
+++ b/controllers/multiclusterobservability/observatorium.go
@@ -321,7 +321,7 @@ func newReceiversSpec(
 	receSpec := obsv1alpha1.ReceiversSpec{}
 	receSpec.Retention = mco.Spec.RetentionConfig.RetentionInLocal
 	receSpec.Replicas = mcoconfig.GetObservabilityComponentReplicas(mcoconfig.ThanosReceive)
-	receSpec.ReplicationFactor = receSpec.Replicas
+	receSpec.ReplicationFactor = &config.Replicas3
 	receSpec.ServiceMonitor = true
 	if !mcoconfig.WithoutResourcesRequests(mco.GetAnnotations()) {
 		receSpec.Resources = mco.Spec.Resources.ThanosReceive


### PR DESCRIPTION
`--receive.replication-factor` is used to define how many times to replicate incoming write requests. it is used to in case deleted raw data. It should not be set the same value of receive replicas. We can keep as 3 replicationFactor w/o change. 

You may have a question how to ensure the thanos query can query the desired data as it has different data in receive instance. You can see that the store is configured as `--store=dnssrv+_grpc._tcp.observability-thanos-receive-default.open-cluster-management-observability.svc.cluster.local`. This configuration will instruct Thanos to discover all endpoints within the observability-thanos-receive-default service in the open-cluster-management-observability namespace and use the declared port named grpc. And query will do deduplication for the same data - https://thanos.io/tip/components/query.md/#deduplication

so we can scale the receive out to handle many managedcluster case.

@bjoydeep @subbarao-meduri @marcolan018 Correct me If I am wrong. Thanks.

Signed-off-by: clyang82 <chuyang@redhat.com>