### PR TITLE
fix dns issue for alertmanager cluster peers.

### DIFF
--- a/manifests/base/alertmanager/alertmanager-statefulset.yaml
+++ b/manifests/base/alertmanager/alertmanager-statefulset.yaml
@@ -48,9 +48,9 @@ spec:
         - --data.retention=120h
         - --web.listen-address=0.0.0.0:9093
         - --web.route-prefix=/
-        - --cluster.peer=alertmanager-0.alertmanager-operated.{{MCO_NAMESPACE}}.svc:9094
-        - --cluster.peer=alertmanager-1.alertmanager-operated.{{MCO_NAMESPACE}}.svc:9094
-        - --cluster.peer=alertmanager-2.alertmanager-operated.{{MCO_NAMESPACE}}.svc:9094
+        - --cluster.peer={{MCO_NAME}}-alertmanager-0.alertmanager-operated.{{MCO_NAMESPACE}}.svc:9094
+        - --cluster.peer={{MCO_NAME}}-alertmanager-1.alertmanager-operated.{{MCO_NAMESPACE}}.svc:9094
+        - --cluster.peer={{MCO_NAME}}-alertmanager-2.alertmanager-operated.{{MCO_NAMESPACE}}.svc:9094
         env:
         - name: POD_IP
           valueFrom:

--- a/pkg/rendering/renderer_alertmanager.go
+++ b/pkg/rendering/renderer_alertmanager.go
@@ -53,6 +53,7 @@ func (r *Renderer) renderAlertManagerStatefulSet(res *resource.Resource) (*unstr
 	spec.Containers[0].ImagePullPolicy = r.cr.Spec.ImagePullPolicy
 	args := spec.Containers[0].Args
 	for idx := range args {
+		args[idx] = strings.Replace(args[idx], "{{MCO_NAME}}", r.cr.Name, 1)
 		args[idx] = strings.Replace(args[idx], "{{MCO_NAMESPACE}}", mcoconfig.GetDefaultNamespace(), 1)
 	}
 


### PR DESCRIPTION
See DNS resolution issue for Alertmanager Cluster Peers:
```
level=warn ts=2021-04-27T08:11:51.795Z caller=cluster.go:461 component=cluster msg=refresh result=failure addr=alertmanager-0.alertmanager-operated.open-cluster-management-observability.svc:9094 err="1 error occurred:\n\t* Failed to resolve alertmanager-0.alertmanager-operated.open-cluster-management-observability.svc:9094: lookup alertmanager-0.alertmanager-operated.open-cluster-management-observability.svc on 172.30.0.10:53: no such host\n\n"
level=warn ts=2021-04-27T08:11:51.853Z caller=cluster.go:461 component=cluster msg=refresh result=failure addr=alertmanager-1.alertmanager-operated.open-cluster-management-observability.svc:9094 err="1 error occurred:\n\t* Failed to resolve alertmanager-1.alertmanager-operated.open-cluster-management-observability.svc:9094: lookup alertmanager-1.alertmanager-operated.open-cluster-management-observability.svc on 172.30.0.10:53: no such host\n\n"
level=warn ts=2021-04-27T08:11:51.865Z caller=cluster.go:461 component=cluster msg=refresh result=failure addr=alertmanager-2.alertmanager-operated.open-cluster-management-observability.svc:9094 err="1 error occurred:\n\t* Failed to resolve alertmanager-2.alertmanager-operated.open-cluster-management-observability.svc:9094: lookup alertmanager-2.alertmanager-operated.open-cluster-management-observability.svc on 172.30.0.10:53: no such host\n\n"
```

Signed-off-by: morvencao <lcao@redhat.com>