### PR TITLE
update ruleSpec.AlertmanagersURL to ruleSpec.AlertmanagerURLs

### DIFF
--- a/controllers/multiclusterobservability/observatorium.go
+++ b/controllers/multiclusterobservability/observatorium.go
@@ -373,7 +373,7 @@ func newRuleSpec(mco *mcov1beta2.MultiClusterObservability, scSelected string) o
 		scSelected)
 
 	//configure alertmanager in ruler
-	ruleSpec.AlertmanagersURL = []string{mcoconfig.AlertmanagerURL}
+	ruleSpec.AlertmanagerURLs = []string{mcoconfig.AlertmanagerURL}
 	ruleSpec.RulesConfig = []obsv1alpha1.RuleConfig{
 		{
 			Name: mcoconfig.AlertRuleDefaultConfigMapName,

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/open-cluster-management/addon-framework v0.0.0-20210414095446-30a5d245b8c7
 	github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f
 	github.com/open-cluster-management/multicloud-operators-placementrule v0.0.0-20210325184301-dd3e27fc2978
-	github.com/open-cluster-management/observatorium-operator v0.0.0-20210421123734-13feeb802b22 
+	github.com/open-cluster-management/observatorium-operator v0.0.0-20210428022751-dc93429038f5
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -688,6 +688,10 @@ github.com/open-cluster-management/multicloud-operators-placementrule v0.0.0-202
 github.com/open-cluster-management/multicloud-operators-placementrule v0.0.0-20210325184301-dd3e27fc2978/go.mod h1:xjRErANcCAoAzsgMMurqW3CHBlNun4PH4elIUWLhNEo=
 github.com/open-cluster-management/observatorium-operator v0.0.0-20210421123734-13feeb802b22 h1:IncbzHyzjHUK3oOhsbhFXev6CGIhjtbV9UNmeWo/GDs=
 github.com/open-cluster-management/observatorium-operator v0.0.0-20210421123734-13feeb802b22/go.mod h1:vWUNIjImrJmNA2Mc1rBUZ5EULzAzfkN/k2Aqr285qvk=
+github.com/open-cluster-management/observatorium-operator v0.0.0-20210427102123-bcdf8ae0192c h1:wIZlDqDXWXc0aUHjsWWbYXnNv6oZcErbbauJZiaqGDA=
+github.com/open-cluster-management/observatorium-operator v0.0.0-20210427102123-bcdf8ae0192c/go.mod h1:2pe1pdg7G1EeuuKbbMAZG+BIHbQAnujtOf9tvilV0Js=
+github.com/open-cluster-management/observatorium-operator v0.0.0-20210428022751-dc93429038f5 h1:eh/+FWhOJna+wZC3FyVWtdN+5RbetIix4ctghVaTnsk=
+github.com/open-cluster-management/observatorium-operator v0.0.0-20210428022751-dc93429038f5/go.mod h1:2pe1pdg7G1EeuuKbbMAZG+BIHbQAnujtOf9tvilV0Js=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=


### PR DESCRIPTION
right now, we cannot specify the alertmanager url in rule because the name is changed in upstream.

Signed-off-by: clyang82 <chuyang@redhat.com>