### PR TITLE
remove the metrics which can be covered by others

### DIFF
--- a/manifests/base/config/metrics_allowlist.yaml
+++ b/manifests/base/config/metrics_allowlist.yaml
@@ -25,7 +25,6 @@ data:
       - cluster_version_payload
       - container_cpu_cfs_periods_total
       - container_cpu_cfs_throttled_periods_total
-      - container_cpu_usage_seconds_total
       - container_fs_limit_bytes
       - container_fs_usage_bytes
       - container_network_receive_bytes_total
@@ -120,10 +119,6 @@ data:
       - node_filesystem_size_bytes
       - node_memory_MemAvailable_bytes
       - node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
-      - node_namespace_pod_container:container_memory_cache
-      - node_namespace_pod_container:container_memory_rss
-      - node_namespace_pod_container:container_memory_swap
-      - node_namespace_pod_container:container_memory_working_set_bytes
       - node_netstat_Tcp_OutSegs
       - node_netstat_Tcp_RetransSegs
       - node_netstat_TcpExt_TCPSynRetrans

--- a/manifests/base/grafana/dash-k8s-compute-resources-node-pods.yaml
+++ b/manifests/base/grafana/dash-k8s-compute-resources-node-pods.yaml
@@ -490,7 +490,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\", container!=\"\"}) by (pod)",
+              "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\", container!=\"\",job=\"kubelet\", metrics_path=\"\/metrics\/cadvisor\", image!=\"\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{pod}}",
@@ -825,7 +825,7 @@ data:
           "pluginVersion": "7.4.2",
           "targets": [
             {
-              "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod)",
+              "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\",job=\"kubelet\", metrics_path=\"\/metrics\/cadvisor\", image!=\"\"}) by (pod)",
               "format": "table",
               "instant": true,
               "intervalFactor": 2,
@@ -844,7 +844,7 @@ data:
               "step": 10
             },
             {
-              "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests{node=\"$node\", resource=\"memory\"}) by (pod)",
+              "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\",job=\"kubelet\", metrics_path=\"\/metrics\/cadvisor\", image!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests{node=\"$node\", resource=\"memory\"}) by (pod)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -864,7 +864,7 @@ data:
               "step": 10
             },
             {
-              "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits{node=\"$node\", resource=\"memory\"}) by (pod)",
+              "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", node=\"$node\",container!=\"\",job=\"kubelet\", metrics_path=\"\/metrics\/cadvisor\", image!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits{node=\"$node\", resource=\"memory\"}) by (pod)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -874,7 +874,7 @@ data:
               "step": 10
             },
             {
-              "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod)",
+              "expr": "sum(container_memory_rss{cluster=\"$cluster\", node=\"$node\",container!=\"\",job=\"kubelet\", metrics_path=\"\/metrics\/cadvisor\", image!=\"\"}) by (pod)",
               "format": "table",
               "instant": true,
               "intervalFactor": 2,
@@ -883,7 +883,7 @@ data:
               "step": 10
             },
             {
-              "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod)",
+              "expr": "sum(container_memory_cache{cluster=\"$cluster\", node=\"$node\",container!=\"\",job=\"kubelet\", metrics_path=\"\/metrics\/cadvisor\", image!=\"\"}) by (pod)",
               "format": "table",
               "instant": true,
               "intervalFactor": 2,
@@ -892,7 +892,7 @@ data:
               "step": 10
             },
             {
-              "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=\"$node\",container!=\"\"}) by (pod)",
+              "expr": "sum(container_memory_swap{cluster=\"$cluster\", node=\"$node\",container!=\"\",job=\"kubelet\", metrics_path=\"\/metrics\/cadvisor\", image!=\"\"}) by (pod)",
               "format": "table",
               "instant": true,
               "intervalFactor": 2,


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11970

remove metrics node_namespace_pod_container:container_memory_* from allowlist, and update dashboards to use container_memory_* 
remove metrics container_cpu_usage_seconds_total, which is not used and in dashboards node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate is used


Signed-off-by: Marco <llan@redhat.com>