### PR TITLE
support metrics removal from default allowlist

### DIFF
--- a/controllers/placementrule/manifestwork_test.go
+++ b/controllers/placementrule/manifestwork_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -167,4 +168,44 @@ func TestManifestWork(t *testing.T) {
 	if err == nil || !errors.IsNotFound(err) {
 		t.Fatalf("Manifestwork not deleted: (%v)", err)
 	}
+}
+
+func TestHandleDeletedMetrics(t *testing.T) {
+	testCaseList := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "no deleted metrics",
+			args: []string{"a", "b"},
+			want: []string{"a", "b"},
+		},
+
+		{
+			name: "no metrics",
+			args: []string{},
+			want: []string{},
+		},
+
+		{
+			name: "have deleted metrics",
+			args: []string{"a", "b", "c-"},
+			want: []string{"a", "b"},
+		},
+
+		{
+			name: "deleted all metrics",
+			args: []string{"a-", "b-", "c-"},
+			want: []string{},
+		},
+	}
+
+	for _, c := range testCaseList {
+		got := handleDeletedMetrics(c.args)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("handleDeletedMetrics() = %v, want %v", got, c.want)
+		}
+	}
+
 }


### PR DESCRIPTION
if a metric name ending in `-`,  we will delete this metric from the default allowlist.

https://github.com/open-cluster-management/backlog/issues/12106

Signed-off-by: Song Song Li <ssli@redhat.com>