### PR TITLE
update Request Rate by  HTTP Return Code panel to show one line per code

### DIFF
--- a/manifests/base/grafana/dash-k8s-apiserver.yaml
+++ b/manifests/base/grafana/dash-k8s-apiserver.yaml
@@ -261,7 +261,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum:apiserver_request_total:5m{instance=~\"$instance\",code=~\"2..\", cluster=\"$cluster\"}",
+              "expr": "sum(sum:apiserver_request_total:5m{instance=~\"$instance\",code=~\"2..\", cluster=\"$cluster\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -269,7 +269,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum:apiserver_request_total:5m{instance=~\"$instance\",code=~\"3..\", cluster=\"$cluster\"}",
+              "expr": "sum(sum:apiserver_request_total:5m{instance=~\"$instance\",code=~\"3..\", cluster=\"$cluster\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -278,7 +278,7 @@ data:
               "refId": "B"
             },
             {
-              "expr": "sum:apiserver_request_total:5m{instance=~\"$instance\",code=~\"4..\", cluster=\"$cluster\"}",
+              "expr": "sum(sum:apiserver_request_total:5m{instance=~\"$instance\",code=~\"4..\", cluster=\"$cluster\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -286,7 +286,7 @@ data:
               "refId": "C"
             },
             {
-              "expr": "sum:apiserver_request_total:5m{instance=~\"$instance\",code=~\"5..\", cluster=\"$cluster\"}",
+              "expr": "sum(sum:apiserver_request_total:5m{instance=~\"$instance\",code=~\"5..\", cluster=\"$cluster\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,


### PR DESCRIPTION
Add sum() to expr, so that only show on line per http code, same as previous dashboard without recording rule.

without sum()
<img width="1021" alt="Screen Shot 2021-05-11 at 9 06 40 AM" src="https://user-images.githubusercontent.com/24226678/117743478-76be6000-b239-11eb-8267-8ed1c4b5d311.png">

with sum()
<img width="1035" alt="Screen Shot 2021-05-11 at 9 06 03 AM" src="https://user-images.githubusercontent.com/24226678/117743513-8473e580-b239-11eb-915b-09d3d7800e89.png">

compared with previous dashboard when no recording rule
<img width="1429" alt="Screen Shot 2021-05-10 at 11 21 44 PM" src="https://user-images.githubusercontent.com/24226678/117743592-a40b0e00-b239-11eb-8270-561ec2ec0c03.png">


Signed-off-by: haoqing0110 <qhao@redhat.com>