### PR TITLE
add the hyphen before the metric name

### DIFF
--- a/controllers/placementrule/manifestwork.go
+++ b/controllers/placementrule/manifestwork.go
@@ -323,10 +323,10 @@ func mergeMetrics(defaultAllowlist []string, customAllowlist []string) []string 
 	customMetrics := []string{}
 	deletedMetrics := map[string]bool{}
 	for _, name := range customAllowlist {
-		if !strings.HasSuffix(name, "-") {
+		if !strings.HasPrefix(name, "-") {
 			customMetrics = append(customMetrics, name)
 		} else {
-			deletedMetrics[strings.TrimSuffix(name, "-")] = true
+			deletedMetrics[strings.TrimPrefix(name, "-")] = true
 		}
 	}
 

--- a/controllers/placementrule/manifestwork_test.go
+++ b/controllers/placementrule/manifestwork_test.go
@@ -207,42 +207,42 @@ func TestHandleDeletedMetrics(t *testing.T) {
 		{
 			name:             "have deleted metrics",
 			defaultAllowlist: []string{"a", "b"},
-			customAllowlist:  []string{"c", "b-"},
+			customAllowlist:  []string{"c", "-b"},
 			want:             []string{"a", "c"},
 		},
 
 		{
 			name:             "deleted metrics is no exist",
 			defaultAllowlist: []string{"a", "b"},
-			customAllowlist:  []string{"c", "d-"},
+			customAllowlist:  []string{"c", "-d"},
 			want:             []string{"a", "b", "c"},
 		},
 
 		{
 			name:             "deleted all metrics",
 			defaultAllowlist: []string{"a", "b"},
-			customAllowlist:  []string{"a-", "b-"},
+			customAllowlist:  []string{"-a", "-b"},
 			want:             []string{},
 		},
 
 		{
 			name:             "delete custorm metrics",
 			defaultAllowlist: []string{"a", "b"},
-			customAllowlist:  []string{"a", "a-"},
+			customAllowlist:  []string{"a", "-a"},
 			want:             []string{"b"},
 		},
 
 		{
 			name:             "have repeated default metrics",
 			defaultAllowlist: []string{"a", "a"},
-			customAllowlist:  []string{"a", "b-"},
+			customAllowlist:  []string{"a", "-b"},
 			want:             []string{"a"},
 		},
 
 		{
 			name:             "have repeated custom metrics",
 			defaultAllowlist: []string{"a"},
-			customAllowlist:  []string{"b", "b", "a-"},
+			customAllowlist:  []string{"b", "b", "-a"},
 			want:             []string{"b"},
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,7 +84,7 @@ const (
 	MemcachedExporterImgRepo = "prom"
 	MemcachedExporterImgName = "memcached-exporter"
 	MemcachedExporterKey     = "memcached_exporter"
-	MemcachedExporterImgTag  = "v0.8.0"
+	MemcachedExporterImgTag  = "v0.9.0"
 
 	GrafanaImgRepo            = "grafana"
 	GrafanaImgName            = "grafana"


### PR DESCRIPTION
- update `memcached-exporter` to v0.9.0
- To add the hyphen "-" before the metric
name. it should be easily sorted and see which metrics are removed
- https://github.com/open-cluster-management/backlog/issues/12106

Signed-off-by: Song Song Li <ssli@redhat.com>