### PR TITLE
remove cluster scoped resources.

### DIFF
--- a/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -14,6 +14,7 @@ import (
 	ocpClientSet "github.com/openshift/client-go/config/clientset/versioned"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	storev1 "k8s.io/api/storage/v1"
 	crdClientSet "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -297,6 +298,12 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 			// remove the StorageVersionMigration resource and ignore error
 			cleanObservabilityStorageVersionMigrationResource(r.Client, mco)
 		}
+		// clean up the cluster resources, eg. clusterrole, clusterrolebinding, etc
+		if err = cleanUpClusterScopedResources(r.Client, mco); err != nil {
+			log.Error(err, "Failed to remove cluster scoped resources")
+			return false, err
+		}
+
 		mco.SetFinalizers(util.Remove(mco.GetFinalizers(), resFinalizer))
 		err = r.Client.Update(context.TODO(), mco)
 		if err != nil {
@@ -675,4 +682,39 @@ func GenerateAlertmanagerRoute(
 		}
 	}
 	return nil, nil
+}
+
+// cleanUpClusterScopedResources delete the cluster scoped resources created by the MCO operator
+// The cluster scoped resources need to be deleted manually because they don't have ownerrefenence set as the MCO CR
+func cleanUpClusterScopedResources(cl client.Client, mco *mcov1beta2.MultiClusterObservability) error {
+	matchLabels := map[string]string{config.GetCrLabelKey(): mco.Name}
+	listOpts := []client.ListOption{
+		client.MatchingLabels(matchLabels),
+	}
+
+	clusterRoleList := &rbacv1.ClusterRoleList{}
+	err := cl.List(context.TODO(), clusterRoleList, listOpts...)
+	if err != nil {
+		return err
+	}
+	for _, clusterRoleRes := range clusterRoleList.Items {
+		err := cl.Delete(context.TODO(), &clusterRoleRes, &client.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	clusterRoleBindingList := &rbacv1.ClusterRoleBindingList{}
+	err = cl.List(context.TODO(), clusterRoleBindingList, listOpts...)
+	if err != nil {
+		return err
+	}
+	for _, clusterRoleBindingRes := range clusterRoleBindingList.Items {
+		err := cl.Delete(context.TODO(), &clusterRoleBindingRes, &client.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	crLabelKey                        = "observability.open-cluster-management.io/name"
 	clusterNameLabelKey               = "cluster"
 	obsAPIGateway                     = "observatorium-api"
 	infrastructureConfigName          = "cluster"
@@ -231,6 +232,11 @@ func SetObservabilityComponentReplicas(name string, replicas *int32) {
 			return
 		}
 	}
+}
+
+// GetCrLabelKey returns the key for the CR label injected into the resources created by the operator
+func GetCrLabelKey() string {
+	return crLabelKey
 }
 
 // GetClusterNameLabelKey returns the key for the injected label

--- a/pkg/rendering/renderer_alertmanager.go
+++ b/pkg/rendering/renderer_alertmanager.go
@@ -23,6 +23,7 @@ func (r *Renderer) newAlertManagerRenderer() {
 		"Service":               r.renderNamespace,
 		"ServiceAccount":        r.renderNamespace,
 		"ConfigMap":             r.renderNamespace,
+		"ClusterRole":           r.renderClusterRole,
 		"ClusterRoleBinding":    r.renderClusterRoleBinding,
 		"Secret":                r.renderNamespace,
 		"Role":                  r.renderNamespace,
@@ -42,6 +43,7 @@ func (r *Renderer) renderAlertManagerStatefulSet(res *resource.Resource) (*unstr
 	if err != nil {
 		return nil, err
 	}
+	crLabelKey := mcoconfig.GetCrLabelKey()
 	dep := obj.(*v1.StatefulSet)
 	dep.ObjectMeta.Labels[crLabelKey] = r.cr.Name
 	dep.Spec.Selector.MatchLabels[crLabelKey] = r.cr.Name

--- a/pkg/rendering/renderer_grafana.go
+++ b/pkg/rendering/renderer_grafana.go
@@ -16,6 +16,7 @@ func (r *Renderer) newGranfanaRenderer() {
 		"Service":               r.renderNamespace,
 		"ServiceAccount":        r.renderNamespace,
 		"ConfigMap":             r.renderNamespace,
+		"ClusterRole":           r.renderClusterRole,
 		"ClusterRoleBinding":    r.renderClusterRoleBinding,
 		"Secret":                r.renderNamespace,
 		"Role":                  r.renderNamespace,

--- a/pkg/rendering/renderer_thanos.go
+++ b/pkg/rendering/renderer_thanos.go
@@ -12,6 +12,7 @@ func (r *Renderer) newThanosRenderer() {
 	r.renderThanosFns = map[string]renderFn{
 		"ServiceAccount":     r.renderNamespace,
 		"ConfigMap":          r.renderNamespace,
+		"ClusterRole":        r.renderClusterRole,
 		"ClusterRoleBinding": r.renderClusterRoleBinding,
 		"Secret":             r.renderNamespace,
 	}


### PR DESCRIPTION
fix: https://github.com/open-cluster-management/backlog/issues/12335

- add CR label `observability.open-cluster-management.io/name` with MCO CR name value to cluster scoped resources, currently only handle **clusterrole** and **clusterrolebinding**

- then delete these cluster scoped resources by the CR label `observability.open-cluster-management.io/name` after MCO CR is deleted

Signed-off-by: morvencao <lcao@redhat.com>