### PR TITLE
update route path for alertmanager.

### DIFF
--- a/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -654,6 +654,7 @@ func GenerateAlertmanagerRoute(
 			Namespace: config.GetDefaultNamespace(),
 		},
 		Spec: routev1.RouteSpec{
+			Path: "/api/v2",
 			Port: &routev1.RoutePort{
 				TargetPort: intstr.FromString("oauth-proxy"),
 			},


### PR DESCRIPTION
fix: https://github.com/open-cluster-management/backlog/issues/12475
Update route path for alertmanager, so that only APIs for alertmanager are exposed.