### PR TITLE
use fitlercache for placementrule&serviceaccount

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,6 +137,9 @@ func main() {
 		v1.SchemeGroupVersion.WithKind("Service"): {
 			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
 		},
+		v1.SchemeGroupVersion.WithKind("ServiceAccount"): {
+			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
+		},
 		appsv1.SchemeGroupVersion.WithKind("Deployment"): {
 			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
 		},
@@ -145,6 +148,9 @@ func main() {
 		},
 		workv1.SchemeGroupVersion.WithKind("ManifestWork"): {
 			LabelSelector: "owner==multicluster-observability-operator",
+		},
+		placementv1.SchemeGroupVersion.WithKind("PlacementRule"): {
+			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
 		},
 	}
 


### PR DESCRIPTION
related with https://github.com/open-cluster-management/backlog/issues/12506
use filteredcache for the watch resources to reduce the memory usage, especially in large scale env

Signed-off-by: Marco <llan@redhat.com>