### PR TITLE
update the default interval to 60s

### DIFF
--- a/api/shared/multiclusterobservability_shared.go
+++ b/api/shared/multiclusterobservability_shared.go
@@ -21,7 +21,7 @@ type ObservabilityAddonSpec struct {
 
 	// Interval for the observability addon push metrics to hub server.
 	// +optional
-	// +kubebuilder:default:=30
+	// +kubebuilder:default:=60
 	// +kubebuilder:validation:Minimum=15
 	// +kubebuilder:validation:Maximum=3600
 	Interval int32 `json:"interval,omitempty"`

--- a/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -77,7 +77,7 @@ spec:
                     description: EnableMetrics indicates the observability addon push metrics to hub server.
                     type: boolean
                   interval:
-                    default: 30
+                    default: 60
                     description: Interval for the observability addon push metrics to hub server.
                     format: int32
                     maximum: 3600
@@ -264,7 +264,7 @@ spec:
                     description: EnableMetrics indicates the observability addon push metrics to hub server.
                     type: boolean
                   interval:
-                    default: 30
+                    default: 60
                     description: Interval for the observability addon push metrics to hub server.
                     format: int32
                     maximum: 3600

--- a/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -37,7 +37,7 @@ spec:
                 description: EnableMetrics indicates the observability addon push metrics to hub server.
                 type: boolean
               interval:
-                default: 30
+                default: 60
                 description: Interval for the observability addon push metrics to hub server.
                 format: int32
                 maximum: 3600

--- a/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -76,7 +76,7 @@ spec:
                       metrics to hub server.
                     type: boolean
                   interval:
-                    default: 30
+                    default: 60
                     description: Interval for the observability addon push metrics
                       to hub server.
                     format: int32
@@ -324,7 +324,7 @@ spec:
                       metrics to hub server.
                     type: boolean
                   interval:
-                    default: 30
+                    default: 60
                     description: Interval for the observability addon push metrics
                       to hub server.
                     format: int32

--- a/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -44,7 +44,7 @@ spec:
                   metrics to hub server.
                 type: boolean
               interval:
-                default: 30
+                default: 60
                 description: Interval for the observability addon push metrics to
                   hub server.
                 format: int32


### PR DESCRIPTION
fix: https://github.com/open-cluster-management/backlog/issues/12622

Signed-off-by: Marco <llan@redhat.com>