### PR TITLE
Remove cluster_operator metrics

### DIFF
--- a/manifests/base/config/metrics_allowlist.yaml
+++ b/manifests/base/config/metrics_allowlist.yaml
@@ -113,10 +113,6 @@ data:
       - node_netstat_Tcp_RetransSegs
       - node_netstat_TcpExt_TCPSynRetrans
       - up
-      - cluster_monitoring_operator_reconcile_errors_total
-      - cluster_monitoring_operator_reconcile_attempts_total
-      - cluster_operator_conditions
-      - cluster_operator_up      
     matches:
       - __name__="workqueue_queue_duration_seconds_bucket",job="apiserver"
       - __name__="workqueue_adds_total",job="apiserver"


### PR DESCRIPTION
Address the comment - https://github.com/open-cluster-management/backlog/issues/11968#issuecomment-829752827
the timeseries:
```
cluster_operator_up  31
cluster_operator_conditions 122
cluster_monitoring_operator_reconcile_errors_total 1
cluster_monitoring_operator_reconcile_attempts_total 1
```
We will enable forwarding alerts from managed cluster to hub alertmanager so that the admin can be notified if there has problems around cluster_operator. 

Signed-off-by: clyang82 <chuyang@redhat.com>