### PR TITLE
use a non recording rule name to query variables

### DIFF
--- a/manifests/base/grafana/dash-k8s-apiserver.yaml
+++ b/manifests/base/grafana/dash-k8s-apiserver.yaml
@@ -1019,7 +1019,7 @@ data:
             "name": "cluster",
             "options": [],
             "query": {
-              "query": "label_values(sum:apiserver_request_total:5m, cluster)",
+              "query": "label_values(process_resident_memory_bytes, cluster)",
               "refId": "Observatorium-cluster-Variable-Query"
             },
             "refresh": 1,
@@ -1050,7 +1050,7 @@ data:
             "name": "instance",
             "options": [],
             "query": {
-              "query": "label_values(sum:apiserver_request_total:5m{cluster=\"$cluster\"}, instance)",
+              "query": "label_values(process_resident_memory_bytes{cluster=\"$cluster\"}, instance)",
               "refId": "Observatorium-instance-Variable-Query"
             },
             "refresh": 1,


### PR DESCRIPTION
In current dashboard, the variables `cluster` and `instance` value are queried from an aggregated metrics name. In simulator, since we are not uploading aggregated data, so variables and simulator dashboard doesn't work as below. 
![Screen Shot 2021-05-27 at 4 46 18 PM](https://user-images.githubusercontent.com/24226678/119795486-19016780-bf0b-11eb-8782-8bc83ff519d2.png)
![Screen Shot 2021-05-27 at 4 46 24 PM](https://user-images.githubusercontent.com/24226678/119795491-1acb2b00-bf0b-11eb-92ff-e3e933f92a75.png)


This fix will use a normal metrics name to query variables, the result is as below:
![Screen Shot 2021-05-27 at 4 43 38 PM](https://user-images.githubusercontent.com/24226678/119795329-f4a58b00-bf0a-11eb-9c50-fa1e47d531d2.png)
![Screen Shot 2021-05-27 at 4 44 19 PM](https://user-images.githubusercontent.com/24226678/119795339-f5d6b800-bf0a-11eb-94ce-532ab96d4fb9.png)

Signed-off-by: haoqing0110 <qhao@redhat.com>