### PR TITLE
add check for non-default field for api-conversion.

### DIFF
--- a/api/v1beta1/multiclusterobservability_conversion.go
+++ b/api/v1beta1/multiclusterobservability_conversion.go
@@ -88,9 +88,11 @@ func (dst *MultiClusterObservability) ConvertFrom(srcRaw conversion.Hub) error {
 	// TODO(morvencao): convert the AvailabilityConfig field
 	// dst.Spec.AvailabilityConfig =
 
-	dst.Spec.RetentionResolutionRaw = src.Spec.AdvancedConfig.RetentionConfig.RetentionResolutionRaw
-	dst.Spec.RetentionResolution5m = src.Spec.AdvancedConfig.RetentionConfig.RetentionResolution5m
-	dst.Spec.RetentionResolution1h = src.Spec.AdvancedConfig.RetentionConfig.RetentionResolution1h
+	if src.Spec.AdvancedConfig != nil && src.Spec.AdvancedConfig.RetentionConfig != nil {
+		dst.Spec.RetentionResolutionRaw = src.Spec.AdvancedConfig.RetentionConfig.RetentionResolutionRaw
+		dst.Spec.RetentionResolution5m = src.Spec.AdvancedConfig.RetentionConfig.RetentionResolution5m
+		dst.Spec.RetentionResolution1h = src.Spec.AdvancedConfig.RetentionConfig.RetentionResolution1h
+	}
 
 	dst.Spec.StorageConfig = &StorageConfigObject{
 		MetricObjectStorage:     src.Spec.StorageConfig.MetricObjectStorage,


### PR DESCRIPTION
Fix nil pointer for api conversion:
```
2021/05/27 09:44:51 http: panic serving 10.129.0.1:39600: runtime error: invalid memory address or nil pointer dereference
goroutine 13975 [running]:
net/http.(*conn).serve.func1(0xc0004f8fa0)
	/usr/local/go/src/net/http/server.go:1824 +0x153
panic(0x1ac2080, 0x2c102e0)
	/usr/local/go/src/runtime/panic.go:971 +0x499
github.com/open-cluster-management/multicluster-observability-operator/api/v1beta1.(*MultiClusterObservability).ConvertFrom(0xc00000af00, 0x1fcb0e0, 0xc000c8e820, 0x1fcb0e0, 0xc000c8e820)
	/workspace/api/v1beta1/multiclusterobservability_conversion.go:91 +0x42
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*Webhook).convertObject(0xc000adc520, 0x1fa7130, 0xc000c8e820, 0x1fa7090, 0xc00000af00, 0x1fa7090, 0xc00000af00)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.0/pkg/webhook/conversion/conversion.go:142 +0x7db
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*Webhook).handleConvertRequest(0xc000adc520, 0xc002913b80, 0xc000721650, 0x0, 0x0)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.0/pkg/webhook/conversion/conversion.go:107 +0x1d6
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*Webhook).ServeHTTP(0xc000adc520, 0x7f6ed297b060, 0xc0012b0550, 0xc000e66300)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.0/pkg/webhook/conversion/conversion.go:74 +0x10e
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1(0x7f6ed297b060, 0xc0012b0550, 0xc000e66300)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.7.1/prometheus/promhttp/instrument_server.go:40 +0xab
net/http.HandlerFunc.ServeHTTP(0xc000ad4690, 0x7f6ed297b060, 0xc0012b0550, 0xc000e66300)
	/usr/local/go/src/net/http/server.go:2069 +0x44
...
```

Signed-off-by: morvencao <lcao@redhat.com>