### PR TITLE
update ingress to use networking.k8s.io/v1

### DIFF
--- a/manifests/base/proxy/ingress.yaml
+++ b/manifests/base/proxy/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: rbac-query-proxy-ingress
@@ -13,6 +13,8 @@ spec:
       paths:
       - path: "/observability-query"
         backend:
-          serviceName: rbac-query-proxy
-          servicePort: 8443
+          service:
+            name: rbac-query-proxy
+            port:
+              number: 8443
         pathType: ImplementationSpecific


### PR DESCRIPTION
Fix https://github.com/open-cluster-management/backlog/issues/13262
Signed-off-by: haoqing0110 <qhao@redhat.com>