### PR TITLE
fix os detection in makefile.

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -45,10 +45,12 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-# use gsed for darwin
-ifeq ("$OSTYPE", "linux-gnu")
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Linux)
 SED=@sed
-else
+endif
+ifeq ($(UNAME), Darwin)
 # run `brew install gnu-sed` to install gsed
 SED=@gsed
 endif


### PR DESCRIPTION
Current OS detection is not correct, when make command is executed on Ubuntu, I still get error:
```
# make manager -f Makefile.prow
...
make: gsed: Command not found
Makefile.prow:92: recipe for target 'manifests' failed
make: *** [manifests] Error 127
```


Signed-off-by: morvencao <lcao@redhat.com>