### PR TITLE
Disable development mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.IntVar(&webhookPort, "webhook-server-port", 9443, "The listening port of the webhook server.")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Disable development mode by default. You can add `- -zap-log-level=debug` to enable the debug.

Signed-off-by: clyang82 <chuyang@redhat.com>