### PR TITLE
delete ownerReferences

### DIFF
--- a/tools/setup-grafana-dev.sh
+++ b/tools/setup-grafana-dev.sh
@@ -107,6 +107,11 @@ EOL
 
   # clean all tmp files
   rm -rf grafana-dev-deploy.yaml* grafana-dev-svc.yaml* grafana-dev-ingress.yaml* grafana-dev-config.ini* grafana-pvc.yaml*
+
+  # delete ownerReferences
+  kubectl patch deployment grafana-dev -p '{"metadata": {"ownerReferences":null}}'
+  kubectl patch svc grafana-dev -p '{"metadata": {"ownerReferences":null}}'
+  kubectl patch ingress grafana-dev -p '{"metadata": {"ownerReferences":null}}'
 }
 
 clean() {


### PR DESCRIPTION
we should not set ownerReferences to grafana-dev related obj. because if we delete cr, then all grafana-dev obj will be deleted. we need to persist the user's grafana-dev env.
https://github.com/open-cluster-management/backlog/issues/13496
Signed-off-by: Song Song Li <ssli@redhat.com>