### PR TITLE
[WIP]limit cache resources.

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -337,7 +337,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ImageManifestConfigMapName + version,
+			Name:      ImageManifestConfigMapNamePrefix + version,
 			Namespace: "ns2",
 		},
 		Data: map[string]string{
@@ -346,6 +346,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 	}
 	os.Setenv("POD_NAMESPACE", "ns2")
 	os.Setenv("COMPONENT_VERSION", version)
+	SetImageManifestConfigMapName()
 	scheme := runtime.NewScheme()
 	corev1.AddToScheme(scheme)
 	client := fake.NewFakeClientWithScheme(scheme, cm)
@@ -357,7 +358,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 		preFunc  func()
 	}{
 		{
-			name:     "read the " + ImageManifestConfigMapName + "2.1.1",
+			name:     "read the " + ImageManifestConfigMapNamePrefix + "2.1.1",
 			expected: true,
 			data: map[string]string{
 				"test-key": "test-value-1",
@@ -365,7 +366,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			preFunc: func() {},
 		},
 		{
-			name:     "Should not read the " + ImageManifestConfigMapName + "2.1.1 again",
+			name:     "Should not read the " + ImageManifestConfigMapNamePrefix + "2.1.1 again",
 			expected: false,
 			data: map[string]string{
 				"test-key": "test-value-1",
@@ -373,12 +374,13 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			preFunc: func() {},
 		},
 		{
-			name:     ImageManifestConfigMapName + "2.1.1 configmap does not exist",
+			name:     ImageManifestConfigMapNamePrefix + "2.1.1 configmap does not exist",
 			expected: true,
 			data:     map[string]string{},
 			preFunc: func() {
 				SetImageManifests(map[string]string{})
 				os.Setenv(ComponentVersion, "invalid")
+				SetImageManifestConfigMapName()
 			},
 		},
 	}


### PR DESCRIPTION
add `cacheResourcesNamespaces` which is the union for all namespaces in which the resources(secret, configmap and serviceaccount...) need to be cached.
this is added to workaround the limitation of controller-filtered-cache, see: https://github.com/IBM/controller-filtered-cache#limitation
to make sure resources outside of the default observability namespace can also be watched
this may add memory footprint of MCO, but shoud be in control.
TODO(morvencao): Remove this once the community support selector logic OR for filter cache: https://github.com/kubernetes-sigs/controller-runtime/blob/master/designs/use-selectors-at-cache.md

Signed-off-by: morvencao <lcao@redhat.com>