### PR TITLE
fix resources watch across multiple namespaces.

### DIFF
--- a/controllers/placementrule/placementrule_controller.go
+++ b/controllers/placementrule/placementrule_controller.go
@@ -473,6 +473,27 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
+	imageManifestPred := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if e.Object.GetName() == config.GetImageManifestConfigMapName() {
+				log.V(1).Info("configmap is created", "configmap", config.GetImageManifestConfigMapName())
+				return true
+			}
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectNew.GetName() == config.GetImageManifestConfigMapName() &&
+				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() {
+				log.V(1).Info("configmap is updated", "configmap", config.GetImageManifestConfigMapName())
+				return true
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+	}
+
 	certSecretPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			if e.Object.GetName() == config.ServerCACerts &&
@@ -574,6 +595,8 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &mcov1beta1.ObservabilityAddon{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(obsAddonPred)).
 		// secondary watch for MCO
 		Watches(&source.Kind{Type: &mcov1beta2.MultiClusterObservability{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(mcoPred)).
+		// Watch the configmap for mch-image-manifest-* update
+		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(imageManifestPred)).
 		// secondary watch for custom allowlist configmap
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(customAllowlistPred)).
 		// secondary watch for certificate secrets

--- a/controllers/placementrule/placementrule_controller.go
+++ b/controllers/placementrule/placementrule_controller.go
@@ -521,6 +521,31 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
+	routeCASecretPred := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if (e.Object.GetNamespace() == config.OpenshiftIngressOperatorNamespace &&
+				e.Object.GetName() == config.OpenshiftIngressRouteCAName) ||
+				(e.Object.GetNamespace() == config.OpenshiftIngressNamespace &&
+					e.Object.GetName() == config.OpenshiftIngressDefaultCertName) {
+				return true
+			}
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if ((e.ObjectNew.GetNamespace() == config.OpenshiftIngressOperatorNamespace &&
+				e.ObjectNew.GetName() == config.OpenshiftIngressRouteCAName) ||
+				(e.ObjectNew.GetNamespace() == config.OpenshiftIngressNamespace &&
+					e.ObjectNew.GetName() == config.OpenshiftIngressDefaultCertName)) &&
+				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() {
+				return true
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+	}
+
 	amAccessorSAPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			if e.Object.GetName() == config.AlertmanagerAccessorSAName &&
@@ -555,6 +580,8 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(certSecretPred)).
 		// secondary watch for alertmanager route byo cert secrets
 		Watches(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(amRouterCertSecretPred)).
+		// secondary watch for openshift route ca secret
+		Watches(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(routeCASecretPred)).
 		// secondary watch for alertmanager accessor serviceaccount
 		Watches(&source.Kind{Type: &corev1.ServiceAccount{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(amAccessorSAPred))
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/open-cluster-management/observatorium-operator v0.0.0-20210512092645-e959481410d7
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49
-	go.uber.org/zap v1.15.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.5
 	k8s.io/apiextensions-apiserver v0.20.2
@@ -29,6 +28,7 @@ require (
 )
 
 replace (
+	github.com/IBM/controller-filtered-cache => github.com/morvencao/controller-filtered-cache v0.2.3-0.20210620083055-ee7b1c3f0554
 	github.com/open-cluster-management/api => github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad
 	golang.org/x/text => golang.org/x/text v0.3.5

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
-github.com/IBM/controller-filtered-cache v0.3.0 h1:RYCPSuLUu7BwE3oMsjv7LCHO2euhLfA/V7wgoRNK3ys=
-github.com/IBM/controller-filtered-cache v0.3.0/go.mod h1:gEDzSQxUwcdScwsw59MTwchTjh6vzLWaSPffIkr85U4=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
@@ -203,7 +201,6 @@ github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v0.3.0 h1:q4c+kbcR0d5rSurhBR8dIgieOaYpXtsdTYfx22Cu6rs=
 github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
@@ -530,6 +527,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/monopole/mdrip v1.0.0/go.mod h1:N1/ppRG9CaPeUKAUHZ3dUlfOT81lTpKZLkyhCvTETwM=
+github.com/morvencao/controller-filtered-cache v0.2.3-0.20210620083055-ee7b1c3f0554 h1:OveSCLYSWr2grUz+diQJAu0AA4N1Dlks31Dn0WyiRlk=
+github.com/morvencao/controller-filtered-cache v0.2.3-0.20210620083055-ee7b1c3f0554/go.mod h1:gEDzSQxUwcdScwsw59MTwchTjh6vzLWaSPffIkr85U4=
 github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -1208,7 +1207,6 @@ sigs.k8s.io/controller-runtime v0.6.2/go.mod h1:vhcq/rlnENJ09SIRp3EveTaZ0yqH526h
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/controller-runtime v0.8.0 h1:s0dYdo7lQgJiAf+alP82PRwbz+oAqL3oSyMQ18XRDOc=
 sigs.k8s.io/controller-runtime v0.8.0/go.mod h1:v9Lbj5oX443uR7GXYY46E0EE2o7k2YxQ58GxVNeXSW4=
-sigs.k8s.io/controller-runtime v0.8.3 h1:GMHvzjTmaWHQB8HadW+dIvBoJuLvZObYJ5YoZruPRao=
 sigs.k8s.io/controller-tools v0.2.8/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
 sigs.k8s.io/controller-tools v0.5.0/go.mod h1:JTsstrMpxs+9BUj6eGuAaEb6SDSPTeVtUyp0jmnAM/I=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=

--- a/main.go
+++ b/main.go
@@ -133,30 +133,32 @@ func main() {
 		os.Exit(1)
 	}
 
-	gvkLabelMap := map[schema.GroupVersionKind]filteredcache.Selector{
-		v1.SchemeGroupVersion.WithKind("Secret"): {
-			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
+	gvkLabelsMap := map[schema.GroupVersionKind][]filteredcache.Selector{
+		v1.SchemeGroupVersion.WithKind("Secret"): []filteredcache.Selector{
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.OpenshiftIngressOperatorNamespace)},
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.OpenshiftIngressNamespace)},
 		},
-		v1.SchemeGroupVersion.WithKind("ConfigMap"): {
-			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
+		v1.SchemeGroupVersion.WithKind("ConfigMap"): []filteredcache.Selector{
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
-		v1.SchemeGroupVersion.WithKind("Service"): {
-			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
+		v1.SchemeGroupVersion.WithKind("Service"): []filteredcache.Selector{
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
-		v1.SchemeGroupVersion.WithKind("ServiceAccount"): {
-			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
+		v1.SchemeGroupVersion.WithKind("ServiceAccount"): []filteredcache.Selector{
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
-		appsv1.SchemeGroupVersion.WithKind("Deployment"): {
-			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
+		appsv1.SchemeGroupVersion.WithKind("Deployment"): []filteredcache.Selector{
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
-		appsv1.SchemeGroupVersion.WithKind("StatefulSet"): {
-			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
+		appsv1.SchemeGroupVersion.WithKind("StatefulSet"): []filteredcache.Selector{
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
-		workv1.SchemeGroupVersion.WithKind("ManifestWork"): {
-			LabelSelector: "owner==multicluster-observability-operator",
+		workv1.SchemeGroupVersion.WithKind("ManifestWork"): []filteredcache.Selector{
+			{LabelSelector: "owner==multicluster-observability-operator"},
 		},
-		placementv1.SchemeGroupVersion.WithKind("PlacementRule"): {
-			FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace()),
+		placementv1.SchemeGroupVersion.WithKind("PlacementRule"): []filteredcache.Selector{
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
 	}
 
@@ -167,7 +169,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b9d51391.open-cluster-management.io",
-		NewCache:               filteredcache.NewFilteredCacheBuilder(gvkLabelMap),
+		NewCache:               filteredcache.NewEnhancedFilteredCacheBuilder(gvkLabelsMap),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/main.go
+++ b/main.go
@@ -169,6 +169,9 @@ func main() {
 		placementv1.SchemeGroupVersion.WithKind("PlacementRule"): []filteredcache.Selector{
 			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
+		operatorv1.SchemeGroupVersion.WithKind("IngressController"): []filteredcache.Selector{
+			{FieldSelector: fmt.Sprintf("metadata.namespace==%s,metadata.name==%s", config.OpenshiftIngressOperatorNamespace, config.OpenshiftIngressOperatorCRName)},
+		},
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ const (
 	OpenshiftIngressNamespace         = "openshift-ingress"
 	OpenshiftIngressOperatorCRName    = "default"
 	OpenshiftIngressDefaultCertName   = "router-certs-default"
+	OpenshiftIngressRouteCAName       = "router-ca"
 
 	AnnotationKeyImageRepository          = "mco-imageRepository"
 	AnnotationKeyImageTagSuffix           = "mco-imageTagSuffix"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ const (
 	DefaultDSImgRepository = "quay.io:443/acm-d"
 	DefaultImgTagSuffix    = "latest"
 
-	ImageManifestConfigMapName = "mch-image-manifest-"
+	ImageManifestConfigMapNamePrefix = "mch-image-manifest-"
 
 	ComponentVersion = "COMPONENT_VERSION"
 
@@ -240,6 +240,7 @@ var (
 	monitoringCRName            = ""
 	tenantUID                   = ""
 	imageManifests              = map[string]string{}
+	imageManifestConfigMapName  = ""
 	hasCustomRuleConfigMap      = false
 	hasCustomAlertmanagerConfig = false
 	certDuration                = time.Hour * 24 * 365
@@ -334,6 +335,17 @@ func GetClusterNameLabelKey() string {
 	return clusterNameLabelKey
 }
 
+func GetImageManifestConfigMapName() string {
+	return imageManifestConfigMapName
+}
+
+func SetImageManifestConfigMapName() {
+	componentVersion, found := os.LookupEnv(ComponentVersion)
+	if found {
+		imageManifestConfigMapName = ImageManifestConfigMapNamePrefix + componentVersion
+	}
+}
+
 // ReadImageManifestConfigMap reads configmap with the name is mch-image-manifest-xxx
 func ReadImageManifestConfigMap(c client.Client) (bool, error) {
 	//Only need to read if imageManifests is empty
@@ -341,10 +353,8 @@ func ReadImageManifestConfigMap(c client.Client) (bool, error) {
 		return false, nil
 	}
 
-	imageCMName := ImageManifestConfigMapName
-	componentVersion, found := os.LookupEnv(ComponentVersion)
-	if found {
-		imageCMName = ImageManifestConfigMapName + componentVersion
+	if imageManifestConfigMapName == "" {
+		SetImageManifestConfigMapName()
 	}
 
 	podNamespace, found := os.LookupEnv("POD_NAMESPACE")
@@ -354,7 +364,7 @@ func ReadImageManifestConfigMap(c client.Client) (bool, error) {
 		err := c.Get(
 			context.TODO(),
 			types.NamespacedName{
-				Name:      imageCMName,
+				Name:      GetImageManifestConfigMapName(),
 				Namespace: podNamespace,
 			},
 			imageCM)
@@ -362,7 +372,7 @@ func ReadImageManifestConfigMap(c client.Client) (bool, error) {
 			imageManifests = imageCM.Data
 		} else {
 			if errors.IsNotFound(err) {
-				log.Info("Cannot get image manifest configmap", "configmap name", imageCMName)
+				log.Info("Cannot get image manifest configmap", "configmap name", GetImageManifestConfigMapName())
 			} else {
 				log.Error(err, "Failed to read mch-image-manifest configmap")
 				return false, err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -337,7 +337,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ImageManifestConfigMapName + version,
+			Name:      ImageManifestConfigMapNamePrefix + version,
 			Namespace: "ns2",
 		},
 		Data: map[string]string{
@@ -346,6 +346,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 	}
 	os.Setenv("POD_NAMESPACE", "ns2")
 	os.Setenv("COMPONENT_VERSION", version)
+	SetImageManifestConfigMapName()
 	scheme := runtime.NewScheme()
 	corev1.AddToScheme(scheme)
 	client := fake.NewFakeClientWithScheme(scheme, cm)
@@ -357,7 +358,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 		preFunc  func()
 	}{
 		{
-			name:     "read the " + ImageManifestConfigMapName + "2.1.1",
+			name:     "read the " + ImageManifestConfigMapNamePrefix + "2.1.1",
 			expected: true,
 			data: map[string]string{
 				"test-key": "test-value-1",
@@ -365,7 +366,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			preFunc: func() {},
 		},
 		{
-			name:     "Should not read the " + ImageManifestConfigMapName + "2.1.1 again",
+			name:     "Should not read the " + ImageManifestConfigMapNamePrefix + "2.1.1 again",
 			expected: false,
 			data: map[string]string{
 				"test-key": "test-value-1",
@@ -373,12 +374,13 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			preFunc: func() {},
 		},
 		{
-			name:     ImageManifestConfigMapName + "2.1.1 configmap does not exist",
+			name:     ImageManifestConfigMapNamePrefix + "2.1.1 configmap does not exist",
 			expected: true,
 			data:     map[string]string{},
 			preFunc: func() {
 				SetImageManifests(map[string]string{})
 				os.Setenv(ComponentVersion, "invalid")
+				SetImageManifestConfigMapName()
 			},
 		},
 	}


### PR DESCRIPTION
Original `controller-filtered-cache` doesn't support selector logic `OR` for the same watching resources, I enhanced the `controller-filtered-cache` in https://github.com/IBM/controller-filtered-cache/pull/28 and now we can build filtered cache with multiple `OR` seletors for the same watching resource. 

pre-work:
- https://github.com/open-cluster-management/multicluster-observability-operator/pull/604
- https://github.com/open-cluster-management/multicluster-observability-operator/pull/610

ref: open-cluster-management/backlog#13426

Signed-off-by: morvencao <lcao@redhat.com>