### PR TITLE
Revert "wait for manifestwork crd before starting manager. (#628)"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -239,7 +239,6 @@ const (
 )
 
 const (
-	ManifestWorkCrdName            = "manifestworks.work.open-cluster-management.io"
 	MCHCrdName                     = "multiclusterhubs.operator.open-cluster-management.io"
 	MCOCrdName                     = "multiclusterobservabilities.observability.open-cluster-management.io"
 	PlacementRuleCrdName           = "placementrules.apps.open-cluster-management.io"


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/13812

This reverts commit 02c4714980535234fa28e0ec872407203afd815d.