### PR TITLE
add annotation to permit user disable proxy

### DIFF
--- a/controllers/multiclusterobservability/observatorium.go
+++ b/controllers/multiclusterobservability/observatorium.go
@@ -207,7 +207,7 @@ func newDefaultObservatoriumSpec(mco *mcov1beta2.MultiClusterObservability,
 	obs.Tolerations = mco.Spec.Tolerations
 	obs.API = newAPISpec(mco)
 	obs.Thanos = newThanosSpec(mco, scSelected)
-	if util.ProxyEnvVarsAreSet() {
+	if config.IsPorxyRequired(mco.GetAnnotations()) {
 		obs.EnvVars = newEnvVars()
 	}
 

--- a/controllers/multiclusterobservability/observatorium.go
+++ b/controllers/multiclusterobservability/observatorium.go
@@ -207,7 +207,7 @@ func newDefaultObservatoriumSpec(mco *mcov1beta2.MultiClusterObservability,
 	obs.Tolerations = mco.Spec.Tolerations
 	obs.API = newAPISpec(mco)
 	obs.Thanos = newThanosSpec(mco, scSelected)
-	if config.IsPorxyRequired(mco.GetAnnotations()) {
+	if config.IsProxyRequired(mco.GetAnnotations()) {
 		obs.EnvVars = newEnvVars()
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,7 @@ const (
 	AnnotationMCOWithoutResourcesRequests = "mco-thanos-without-resources-requests"
 	AnnotationSkipCreation                = "skip-creation-if-exist"
 	AnnotationCertDuration                = "mco-cert-duration"
+	AnnotationProxyDisable                = "mco-proxy-disable"
 
 	DefaultImgRepository   = "quay.io/open-cluster-management"
 	DefaultDSImgRepository = "quay.io:443/acm-d"
@@ -577,6 +578,27 @@ func IsPaused(annotations map[string]string) bool {
 	}
 
 	return false
+}
+
+// IsPorxyRequired returns true if PROXY env is available and there is no mco-proxy-disable:true annotation in mco instance
+// OLM handles these environment variables as a unit;
+// if at least one of them is set, all three are considered overridden
+// and the cluster-wide defaults are not used for the deployments of the subscribed Operator.
+// https://docs.openshift.com/container-platform/4.6/operators/admin/olm-configuring-proxy-support.html
+func IsPorxyRequired(annotations map[string]string) bool {
+	if os.Getenv("HTTP_PROXY") == "" && os.Getenv("HTTPS_PROXY") == "" && os.Getenv("NO_PROXY") == "" {
+		return false
+	}
+	if annotations == nil {
+		return true
+	}
+
+	if annotations[AnnotationProxyDisable] != "" &&
+		strings.EqualFold(annotations[AnnotationProxyDisable], "true") {
+		return false
+	}
+
+	return true
 }
 
 // WithoutResourcesRequests returns true if the multiclusterobservability instance has annotation:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,7 +49,7 @@ const (
 	AnnotationMCOWithoutResourcesRequests = "mco-thanos-without-resources-requests"
 	AnnotationSkipCreation                = "skip-creation-if-exist"
 	AnnotationCertDuration                = "mco-cert-duration"
-	AnnotationProxyDisable                = "mco-proxy-disable"
+	AnnotationProxyIgnore                 = "mco-proxy-ignore"
 
 	DefaultImgRepository   = "quay.io/open-cluster-management"
 	DefaultDSImgRepository = "quay.io:443/acm-d"
@@ -580,12 +580,12 @@ func IsPaused(annotations map[string]string) bool {
 	return false
 }
 
-// IsPorxyRequired returns true if PROXY env is available and there is no mco-proxy-disable:true annotation in mco instance
+// IsProxyRequired returns true if PROXY env is available and there is no mco-proxy-ignore:true annotation in mco instance
 // OLM handles these environment variables as a unit;
 // if at least one of them is set, all three are considered overridden
 // and the cluster-wide defaults are not used for the deployments of the subscribed Operator.
 // https://docs.openshift.com/container-platform/4.6/operators/admin/olm-configuring-proxy-support.html
-func IsPorxyRequired(annotations map[string]string) bool {
+func IsProxyRequired(annotations map[string]string) bool {
 	if os.Getenv("HTTP_PROXY") == "" && os.Getenv("HTTPS_PROXY") == "" && os.Getenv("NO_PROXY") == "" {
 		return false
 	}
@@ -593,8 +593,8 @@ func IsPorxyRequired(annotations map[string]string) bool {
 		return true
 	}
 
-	if annotations[AnnotationProxyDisable] != "" &&
-		strings.EqualFold(annotations[AnnotationProxyDisable], "true") {
+	if annotations[AnnotationProxyIgnore] != "" &&
+		strings.EqualFold(annotations[AnnotationProxyIgnore], "true") {
 		return false
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"os"
 
 	"github.com/open-cluster-management/multicluster-observability-operator/pkg/config"
 	appsv1 "k8s.io/api/apps/v1"
@@ -86,16 +85,4 @@ func GeneratePassword(n int) (string, error) {
 	}
 
 	return base64.StdEncoding.EncodeToString(b), err
-}
-
-// ProxyEnvVarsAreSet ...
-// OLM handles these environment variables as a unit;
-// if at least one of them is set, all three are considered overridden
-// and the cluster-wide defaults are not used for the deployments of the subscribed Operator.
-// https://docs.openshift.com/container-platform/4.6/operators/admin/olm-configuring-proxy-support.html
-func ProxyEnvVarsAreSet() bool {
-	if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" || os.Getenv("NO_PROXY") != "" {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
in some customer's env, the objectstorage also maybe located in internal network. In that case no proxy is required even if HTTP_PROXY is set by OLM
Add an annotation mco-porxy-disable to let user has the option to disable the PROXY env in mco CR

Signed-off-by: Marco <llan@redhat.com>