### PR TITLE
Support 311

### DIFF
--- a/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -258,6 +258,11 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+		// create the placementrule
+		err = create311PlacementRule(r.Client, r.Scheme, instance)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	svmCrdExists, _ := r.CRDMap[config.StorageVersionMigrationCrdName]

--- a/controllers/multiclusterobservability/placementrule.go
+++ b/controllers/multiclusterobservability/placementrule.go
@@ -89,3 +89,74 @@ func createPlacementRule(client client.Client, scheme *runtime.Scheme,
 	log.Info("PlacementRule already existed", "name", name)
 	return nil
 }
+
+func create311PlacementRule(client client.Client, scheme *runtime.Scheme,
+	mco *mcov1beta2.MultiClusterObservability) error {
+	name := config.Placement311CRName
+	namespace := config.GetDefaultNamespace()
+	p := &appsv1.PlacementRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.PlacementRuleSpec{
+			GenericPlacementFields: appsv1.GenericPlacementFields{
+				ClusterSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "observability",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"disabled"},
+						},
+						{
+							Key:      "vendor",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"OpenShift"},
+						},
+						{
+							Key:      "openshiftVersion",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"3"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Set MultiClusterObservability instance as the owner and controller
+	if namespace == config.GetDefaultNamespace() {
+		if err := controllerutil.SetControllerReference(mco, p, scheme); err != nil {
+			return err
+		}
+	}
+
+	found := &appsv1.PlacementRule{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		log.Info("Creating PlacementRule", "name", name)
+		err = client.Create(context.TODO(), p)
+		if err != nil {
+			log.Error(err, "Failed to create PlacementRule", "name", name)
+			return err
+		}
+		return nil
+	} else if err != nil {
+		log.Error(err, "Failed to check PlacementRule", "name", name)
+		return err
+	}
+
+	if !reflect.DeepEqual(found.Spec, p.Spec) {
+		log.Info("Reverting PlacementRule", "name", name)
+		p.ObjectMeta.ResourceVersion = found.ObjectMeta.ResourceVersion
+		err = client.Update(context.TODO(), p)
+		if err != nil {
+			log.Error(err, "Failed to revert PlacementRule", "name", name)
+			return err
+		}
+		return nil
+	}
+
+	log.Info("PlacementRule already existed", "name", name)
+	return nil
+}

--- a/controllers/placementrule/endpoint_metrics_operator.go
+++ b/controllers/placementrule/endpoint_metrics_operator.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 
@@ -28,31 +29,36 @@ var (
 )
 
 func loadTemplates(mco *mcov1beta2.MultiClusterObservability) (
-	[]runtime.RawExtension, *apiextensionsv1.CustomResourceDefinition, *appsv1.Deployment, error) {
+	[]runtime.RawExtension, *apiextensionsv1.CustomResourceDefinition, *apiextensionsv1beta1.CustomResourceDefinition, *appsv1.Deployment, error) {
 	templateRenderer := templates.NewTemplateRenderer(templatePath)
 	resourceList := []*resource.Resource{}
 	err := templateRenderer.AddTemplateFromPath(templatePath, &resourceList)
 	if err != nil {
 		log.Error(err, "Failed to load templates")
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	crd := &apiextensionsv1.CustomResourceDefinition{}
+	crdv1 := &apiextensionsv1.CustomResourceDefinition{}
+	crdv1beta1 := &apiextensionsv1beta1.CustomResourceDefinition{}
 	dep := &appsv1.Deployment{}
 	rawExtensionList := []runtime.RawExtension{}
 	for _, r := range resourceList {
 		obj, err := updateRes(r, mco)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		if r.GetKind() == "Deployment" {
 			dep = obj.(*appsv1.Deployment)
 		} else if r.GetKind() == "CustomResourceDefinition" {
-			crd = obj.(*apiextensionsv1.CustomResourceDefinition)
+			if r.GetGvk().Version == "v1" {
+				crdv1 = obj.(*apiextensionsv1.CustomResourceDefinition)
+			} else {
+				crdv1beta1 = obj.(*apiextensionsv1beta1.CustomResourceDefinition)
+			}
 		} else {
 			rawExtensionList = append(rawExtensionList, runtime.RawExtension{Object: obj})
 		}
 	}
-	return rawExtensionList, crd, dep, nil
+	return rawExtensionList, crdv1, crdv1beta1, dep, nil
 }
 
 func updateRes(r *resource.Resource,
@@ -63,6 +69,9 @@ func updateRes(r *resource.Resource,
 		r.SetNamespace(spokeNameSpace)
 	}
 	obj := util.GetK8sObj(kind)
+	if kind == "CustomResourceDefinition" && r.GetGvk().Version == "v1beta1" {
+		obj = &apiextensionsv1beta1.CustomResourceDefinition{}
+	}
 	obj.GetObjectKind()
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(r.Map(), obj)
 	if err != nil {

--- a/controllers/placementrule/manifestwork.go
+++ b/controllers/placementrule/manifestwork.go
@@ -151,13 +151,13 @@ func createManifestwork(c client.Client, work *workv1.ManifestWork) error {
 }
 
 func getGlobalManifestResources(c client.Client, mco *mcov1beta2.MultiClusterObservability) (
-	[]workv1.Manifest, *workv1.Manifest, *appsv1.Deployment, *corev1.Secret, error) {
+	[]workv1.Manifest, *workv1.Manifest, *workv1.Manifest, *appsv1.Deployment, *corev1.Secret, error) {
 
 	works := []workv1.Manifest{}
 
 	hubInfo, err := newHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, mco)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 
 	// inject namespace
@@ -166,7 +166,7 @@ func getGlobalManifestResources(c client.Client, mco *mcov1beta2.MultiClusterObs
 	//create image pull secret
 	pull, err := getPullSecret(c, config.GetImagePullSecret(mco.Spec))
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	if pull != nil {
 		works = injectIntoWork(works, pull)
@@ -175,38 +175,42 @@ func getGlobalManifestResources(c client.Client, mco *mcov1beta2.MultiClusterObs
 	// inject the certificates
 	certs, err := getCerts(c)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	works = injectIntoWork(works, certs)
 
 	// inject the metrics allowlist configmap
 	mList, err := getMetricsListCM(c)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	works = injectIntoWork(works, mList)
 
 	// inject the alertmanager accessor bearer token secret
 	amAccessorTokenSecret, err := getAmAccessorTokenSecret(c)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	works = injectIntoWork(works, amAccessorTokenSecret)
 
 	// inject resouces in templates
-	templates, crd, dep, err := loadTemplates(mco)
+	templates, crdv1, crdv1beta1, dep, err := loadTemplates(mco)
 	if err != nil {
 		log.Error(err, "Failed to load templates")
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
-	crdWork := &workv1.Manifest{RawExtension: runtime.RawExtension{
-		Object: crd,
+
+	crdv1Work := &workv1.Manifest{RawExtension: runtime.RawExtension{
+		Object: crdv1,
+	}}
+	crdv1beta1Work := &workv1.Manifest{RawExtension: runtime.RawExtension{
+		Object: crdv1beta1,
 	}}
 	for _, raw := range templates {
 		works = append(works, workv1.Manifest{RawExtension: raw})
 	}
 
-	return works, crdWork, dep, hubInfo, nil
+	return works, crdv1Work, crdv1beta1Work, dep, hubInfo, nil
 }
 
 func createManifestWorks(c client.Client, restMapper meta.RESTMapper,

--- a/controllers/placementrule/manifestwork_test.go
+++ b/controllers/placementrule/manifestwork_test.go
@@ -159,7 +159,7 @@ func TestManifestWork(t *testing.T) {
 	}
 	templatePath = path.Join(wd, "../../manifests/endpoint-observability")
 
-	works, crdWork, dep, hubInfo, err := getGlobalManifestResources(c, newTestMCO())
+	works, crdWork, _, dep, hubInfo, err := getGlobalManifestResources(c, newTestMCO())
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resourc: (%v)", err)
 	}
@@ -182,7 +182,7 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create pull secret: (%v)", err)
 	}
-	works, crdWork, dep, hubInfo, err = getGlobalManifestResources(c, newTestMCO())
+	works, crdWork, _, dep, hubInfo, err = getGlobalManifestResources(c, newTestMCO())
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resourc: (%v)", err)
 	}

--- a/controllers/placementrule/placementrule_controller.go
+++ b/controllers/placementrule/placementrule_controller.go
@@ -445,16 +445,18 @@ func deleteManagedClusterRes(c client.Client, namespace string) error {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	name := config.GetDefaultCRName()
 	pmPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			if e.Object.GetName() == name && e.Object.GetNamespace() == watchNamespace {
+			if (e.Object.GetName() == config.GetDefaultCRName() ||
+				e.Object.GetName() == config.Placement311CRName) &&
+				e.Object.GetNamespace() == watchNamespace {
 				return true
 			}
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectNew.GetName() == name &&
+			if (e.ObjectNew.GetName() == config.GetDefaultCRName() ||
+				e.ObjectNew.GetName() == config.Placement311CRName) &&
 				e.ObjectNew.GetNamespace() == watchNamespace &&
 				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() {
 				return true
@@ -462,7 +464,9 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			if e.Object.GetName() == name && e.Object.GetNamespace() == watchNamespace {
+			if (e.Object.GetName() == config.GetDefaultCRName() ||
+				e.Object.GetName() == config.Placement311CRName) &&
+				e.Object.GetNamespace() == watchNamespace {
 				return e.DeleteStateUnknown
 			}
 			return false

--- a/controllers/placementrule/placementrule_controller.go
+++ b/controllers/placementrule/placementrule_controller.go
@@ -117,6 +117,22 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 		}
 	}
+	placement311 := &placementv1.PlacementRule{}
+	if !deleteAll {
+		// Fetch the PlacementRule instance
+		err = r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      config.Placement311CRName,
+			Namespace: config.GetDefaultNamespace(),
+		}, placement311)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				deleteAll = true
+			} else {
+				// Error reading the object - requeue the request.
+				return ctrl.Result{}, err
+			}
+		}
+	}
 
 	// Do not reconcile objects if this instance of mch is labeled "paused"
 	if config.IsPaused(mco.GetAnnotations()) {
@@ -165,7 +181,7 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if !deleteAll {
-		res, err := createAllRelatedRes(r.Client, r.RESTMapper, req, mco, placement, obsAddonList)
+		res, err := createAllRelatedRes(r.Client, r.RESTMapper, req, mco, placement, placement311, obsAddonList)
 		if err != nil {
 			return res, err
 		}
@@ -250,6 +266,7 @@ func createAllRelatedRes(
 	request ctrl.Request,
 	mco *mcov1beta2.MultiClusterObservability,
 	placement *placementv1.PlacementRule,
+	placement311 *placementv1.PlacementRule,
 	obsAddonList *mcov1beta1.ObservabilityAddonList) (ctrl.Result, error) {
 
 	// create the clusterrole if not there
@@ -278,7 +295,7 @@ func createAllRelatedRes(
 		currentClusters = append(currentClusters, ep.Namespace)
 	}
 
-	works, crdWork, dep, hubInfo, err := getGlobalManifestResources(client, mco)
+	works, crdv1Work, crdv1beta1Work, dep, hubInfo, err := getGlobalManifestResources(client, mco)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -292,7 +309,25 @@ func createAllRelatedRes(
 			log.Info("Monitoring operator should be installed in cluster", "cluster_name", decision.ClusterName)
 			err = createManagedClusterRes(client, restMapper, mco,
 				decision.ClusterName, decision.ClusterNamespace,
-				works, crdWork, dep, hubInfo)
+				works, crdv1Work, dep, hubInfo)
+			if err != nil {
+				failedCreateManagedClusterRes = true
+				log.Error(err, "Failed to create managedcluster resources", "namespace", decision.ClusterNamespace)
+			}
+			if request.Namespace == decision.ClusterNamespace {
+				break
+			}
+		}
+	}
+	for _, decision := range placement311.Status.Decisions {
+		currentClusters = util.Remove(currentClusters, decision.ClusterNamespace)
+		// only handle the request namespace if the request resource is not from observability  namespace
+		if request.Namespace == "" || request.Namespace == config.GetDefaultNamespace() ||
+			request.Namespace == decision.ClusterNamespace {
+			log.Info("Monitoring operator should be installed in cluster", "cluster_name", decision.ClusterName)
+			err = createManagedClusterRes(client, restMapper, mco,
+				decision.ClusterName, decision.ClusterNamespace,
+				works, crdv1beta1Work, dep, hubInfo)
 			if err != nil {
 				failedCreateManagedClusterRes = true
 				log.Error(err, "Failed to create managedcluster resources", "namespace", decision.ClusterNamespace)

--- a/controllers/placementrule/placementrule_controller_test.go
+++ b/controllers/placementrule/placementrule_controller_test.go
@@ -35,6 +35,7 @@ const (
 	namespace2   = "test-ns-2"
 	clusterName  = "cluster1"
 	clusterName2 = "cluster2"
+	clusterName3 = "cluster3"
 	mcoName      = "test-mco"
 )
 
@@ -114,6 +115,20 @@ func TestObservabilityAddonController(t *testing.T) {
 			},
 		},
 	}
+	p2 := &placementv1.PlacementRule{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      config.Placement311CRName,
+			Namespace: mcoNamespace,
+		},
+		Status: placementv1.PlacementRuleStatus{
+			Decisions: []placementv1.PlacementDecision{
+				{
+					ClusterName:      clusterName3,
+					ClusterNamespace: namespace,
+				},
+			},
+		},
+	}
 	mco := newTestMCO()
 	pull := newTestPullSecret()
 	deprecatedRole := &rbacv1.Role{
@@ -125,7 +140,7 @@ func TestObservabilityAddonController(t *testing.T) {
 			},
 		},
 	}
-	objs := []runtime.Object{p, mco, pull, newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret(), newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
+	objs := []runtime.Object{p, p2, mco, pull, newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret(), newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
 		NewAmAccessorSA(), NewAmAccessorTokenSecret(), newManagedClusterAddon(), deprecatedRole}
 	c := fake.NewFakeClient(objs...)
 	r := &PlacementRuleReconciler{Client: c, Scheme: s, CRDMap: map[string]bool{config.PlacementRuleCrdName: true}}

--- a/controllers/placementrule/role.go
+++ b/controllers/placementrule/role.go
@@ -191,6 +191,22 @@ func createResourceRole(c client.Client) error {
 					"addon.open-cluster-management.io",
 				},
 			},
+			{
+				Resources: []string{
+					"leases",
+				},
+				Verbs: []string{
+					"watch",
+					"list",
+					"get",
+					"update",
+					"create",
+					"delete",
+				},
+				APIGroups: []string{
+					"coordination.k8s.io",
+				},
+			},
 		},
 	}
 

--- a/controllers/placementrule/role_test.go
+++ b/controllers/placementrule/role_test.go
@@ -124,7 +124,7 @@ func TestCreateRole(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Role: (%v)", err)
 	}
-	if len(found.Rules) != 3 {
+	if len(found.Rules) != 4 {
 		t.Fatalf("role is no created correctly")
 	}
 
@@ -164,7 +164,7 @@ func TestCreateRole(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to update Role: (%v)", err)
 	}
-	if len(found.Rules) != 3 {
+	if len(found.Rules) != 4 {
 		t.Fatalf("role is no updated correctly")
 	}
 }

--- a/manifests/endpoint-observability/kustomization.yaml
+++ b/manifests/endpoint-observability/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - operator.yaml
 - service_account.yaml
 - observability.open-cluster-management.io_observabilityaddon_crd.yaml
+- observability.open-cluster-management.io_observabilityaddon_v1beta1_crd.yaml

--- a/manifests/endpoint-observability/observability.open-cluster-management.io_observabilityaddon_v1beta1_crd.yaml
+++ b/manifests/endpoint-observability/observability.open-cluster-management.io_observabilityaddon_v1beta1_crd.yaml
@@ -1,11 +1,8 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: observabilityaddons.observability.open-cluster-management.io
 spec:
   group: observability.open-cluster-management.io

--- a/manifests/endpoint-observability/observability.open-cluster-management.io_observabilityaddon_v1beta1_crd.yaml
+++ b/manifests/endpoint-observability/observability.open-cluster-management.io_observabilityaddon_v1beta1_crd.yaml
@@ -1,8 +1,10 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   name: observabilityaddons.observability.open-cluster-management.io
 spec:
   group: observability.open-cluster-management.io
@@ -13,103 +15,103 @@ spec:
     shortNames:
     - oba
     singular: observabilityaddon
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ObservabilityAddon is the Schema for the observabilityaddon API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ObservabilityAddonSpec is the spec of observability addon
+          properties:
+            enableMetrics:
+              description: EnableMetrics indicates the observability addon push metrics
+                to hub server.
+              type: boolean
+            interval:
+              description: Interval for the observability addon push metrics to hub
+                server.
+              format: int32
+              maximum: 3600
+              minimum: 15
+              type: integer
+            resources:
+              description: Resource requirement for metrics-collector
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  type: object
+              type: object
+          type: object
+        status:
+          description: ObservabilityAddonStatus defines the observed state of ObservabilityAddon
+          properties:
+            conditions:
+              items:
+                description: StatusCondition contains condition information for an
+                  observability addon
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+      type: object
+  version: v1beta1
   versions:
   - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ObservabilityAddon is the Schema for the observabilityaddon API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ObservabilityAddonSpec is the spec of observability addon
-            properties:
-              enableMetrics:
-                default: true
-                description: EnableMetrics indicates the observability addon push
-                  metrics to hub server.
-                type: boolean
-              interval:
-                default: 60
-                description: Interval for the observability addon push metrics to
-                  hub server.
-                format: int32
-                maximum: 3600
-                minimum: 15
-                type: integer
-              resources:
-                description: Resource requirement for metrics-collector
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                    type: object
-                type: object
-            type: object
-          status:
-            description: ObservabilityAddonStatus defines the observed state of ObservabilityAddon
-            properties:
-              conditions:
-                items:
-                  description: StatusCondition contains condition information for
-                    an observability addon
-                  properties:
-                    lastTransitionTime:
-                      format: date-time
-                      type: string
-                    message:
-                      type: string
-                    reason:
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-            required:
-            - conditions
-            type: object
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ const (
 	defaultNamespace                  = "open-cluster-management-observability"
 	defaultTenantName                 = "default"
 	defaultCRName                     = "observability"
+	Placement311CRName                = "observability-311"
 	operandNamePrefix                 = "observability-"
 	OpenshiftIngressOperatorNamespace = "openshift-ingress-operator"
 	OpenshiftIngressNamespace         = "openshift-ingress"


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/14284

The idea is to create a new placementrule to select only openshift 311 cluster. likes:
```
      matchExpressions:
      - key: observability
        operator: NotIn
        values:
        - disabled
      - key: vendor
        operator: In
        values:
        - OpenShift
      - key: openshiftVersion
        operator: In
        values:
        - "3"
```
for 311, we need to apply `v1beta1` oba crd.

Signed-off-by: clyang82 <chuyang@redhat.com>