### PR TITLE
add timeout for alertmgr

### DIFF
--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -227,7 +227,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_advanced_config_test.go
+++ b/tests/pkg/tests/observability_advanced_config_test.go
@@ -163,7 +163,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -238,7 +238,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_cert_renew_test.go
+++ b/tests/pkg/tests/observability_cert_renew_test.go
@@ -145,7 +145,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_custom_dashboards_test.go
+++ b/tests/pkg/tests/observability_custom_dashboards_test.go
@@ -65,7 +65,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_default_config_test.go
+++ b/tests/pkg/tests/observability_default_config_test.go
@@ -88,7 +88,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_endpoint_preserve_test.go
+++ b/tests/pkg/tests/observability_endpoint_preserve_test.go
@@ -140,7 +140,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_grafana_dev_test.go
+++ b/tests/pkg/tests/observability_grafana_dev_test.go
@@ -31,7 +31,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_grafana_test.go
+++ b/tests/pkg/tests/observability_grafana_test.go
@@ -31,7 +31,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_manifestwork_test.go
+++ b/tests/pkg/tests/observability_manifestwork_test.go
@@ -97,7 +97,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_metricslist_test.go
+++ b/tests/pkg/tests/observability_metricslist_test.go
@@ -75,7 +75,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_observatorium_preserve_test.go
+++ b/tests/pkg/tests/observability_observatorium_preserve_test.go
@@ -74,7 +74,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_reconcile_test.go
+++ b/tests/pkg/tests/observability_reconcile_test.go
@@ -194,7 +194,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/tests/pkg/tests/observability_retention_test.go
+++ b/tests/pkg/tests/observability_retention_test.go
@@ -155,7 +155,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
alertmanager takes 4 minutes to start, so we need to set a timeout for `IntegrityChecking`
https://github.com/open-cluster-management/backlog/issues/14486
Signed-off-by: Song Song Li <ssli@redhat.com>