### PR TITLE
Add Assisted Installer metrics to metrics_allowlist

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -9,6 +9,14 @@ data:
       - ALERTS
       - authenticated_user_requests
       - authentication_attempts
+      - assisted_installer_cluster_creations  # counter
+      - assisted_installer_cluster_installation_started # counter
+      - assisted_installer_cluster_installation_second # histogram
+      - assisted_installer_cluster_host_installation_count # histogram
+      - assisted_installer_host_installation_phase_seconds # histogram
+      - assisted_installer_cluster_host_disk_sync_duration_ms # histogram
+      - assisted_installer_cluster_host_image_pull_status # histogram
+      - assisted_installer_filesystem_usage_percentage # Gauge
       - cluster:capacity_cpu_cores:sum
       - cluster:capacity_memory_bytes:sum
       - cluster:container_cpu_usage:ratio


### PR DESCRIPTION
Here's the list of name, types, and description for the assisted metrics being added in this PR

* assisted_installer_cluster_creations (counter): Number of cluster
  resources created, by version

* assisted_installer_cluster_installation_started (counter): Number of
  clusters that entered “installing” state, by version

* assisted_installer_cluster_installation_second (histogram):
  Histogram/sum/count of installation time for completed clusters, by
  result and OCP version (1 per cluster)

* assisted_installer_cluster_host_installation_count (histogram): Number
  of hosts per cluster when the installation started (1 per cluster)

* assisted_installer_host_installation_phase_seconds (histogram):
  Histogram/sum/count of time for each phase, by phase, final install
  result, and OCP version (Number of phases (~5) per Number of hosts in the cluster)

* assisted_installer_cluster_host_disk_sync_duration_ms (histogram):
  Histogram/sum/count of the disk's fdatasync duration (fetched from fio) (1 per host)

* assisted_installer_cluster_host_image_pull_status (histogram):
  Histogram / sum / count of the images' pull statuses (1 per image)

* assisted_installer_filesystem_usage_percentage (Gauge): The percentage
  of the filesystem usage by the service


There could be >=1k clusters at any point in time, which may have more than 1 host each.

Signed-off-by: Flavio Percoco <flavio@redhat.com>