### PR TITLE
clean up the operand names map for cr deletion.

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -283,8 +283,9 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 			return false, err
 		}
 
-		// clean up operand names map
+		// clean up operand names and image manifests map
 		config.CleanUpOperandNames()
+		config.CleanUpImageManifests()
 
 		mco.SetFinalizers(util.Remove(mco.GetFinalizers(), resFinalizer))
 		err := r.Client.Update(context.TODO(), mco)

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -283,6 +283,9 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 			return false, err
 		}
 
+		// clean up operand names map
+		config.CleanUpOperandNames()
+
 		mco.SetFinalizers(util.Remove(mco.GetFinalizers(), resFinalizer))
 		err := r.Client.Update(context.TODO(), mco)
 		if err != nil {

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -390,6 +390,14 @@ func SetImageManifests(images map[string]string) {
 	imageManifests = images
 }
 
+// CleanUpImageManifests reset imageManifests
+// Should be called when the MCO CR is deleted
+func CleanUpImageManifests() {
+	for k := range imageManifests {
+		delete(imageManifests, k)
+	}
+}
+
 // ReplaceImage is used to replace the image with specified annotation or imagemanifest configmap
 func ReplaceImage(annotations map[string]string, imageRepo, componentName string) (bool, string) {
 	if annotations != nil {
@@ -991,7 +999,7 @@ func SetOperandNames(c client.Client) error {
 }
 
 // CleanUpOperandNames delete all the operand name items
-// should be called when the MCO CR is deleted
+// Should be called when the MCO CR is deleted
 func CleanUpOperandNames() {
 	for k := range operandNames {
 		delete(operandNames, k)

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -989,3 +989,11 @@ func SetOperandNames(c client.Client) error {
 
 	return nil
 }
+
+// CleanUpOperandNames delete all the operand name items
+// should be called when the MCO CR is deleted
+func CleanUpOperandNames() {
+	for k := range operandNames {
+		delete(operandNames, k)
+	}
+}

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -892,9 +892,7 @@ func TestGetOperandName(t *testing.T) {
 			componentName: Alertmanager,
 			prepare: func() {
 				//clean the operandNames map
-				for k := range operandNames {
-					delete(operandNames, k)
-				}
+				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
 					ObjectMeta: metav1.ObjectMeta{
@@ -936,9 +934,7 @@ func TestGetOperandName(t *testing.T) {
 			componentName: Alertmanager,
 			prepare: func() {
 				//clean the operandNames map
-				for k := range operandNames {
-					delete(operandNames, k)
-				}
+				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
 					ObjectMeta: metav1.ObjectMeta{
@@ -987,9 +983,7 @@ func TestGetOperandName(t *testing.T) {
 			componentName: Alertmanager,
 			prepare: func() {
 				//clean the operandNames map
-				for k := range operandNames {
-					delete(operandNames, k)
-				}
+				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/14560

This PR is to fix the inconsistent operand names after MCO is upgraded from release-2.2 and then create new MCO CR.

Need to be cherry-picked to release-2.3 Z stream.

Signed-off-by: morvencao <lcao@redhat.com>