### PR TITLE
cherrypick 669 to cleanup cache for mco cr deletion

### DIFF
--- a/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -301,6 +301,10 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 			return false, err
 		}
 
+		// clean up operand names and image manifests map
+		config.CleanUpOperandNames()
+		config.CleanUpImageManifests()
+
 		mco.SetFinalizers(util.Remove(mco.GetFinalizers(), resFinalizer))
 		err := r.Client.Update(context.TODO(), mco)
 		if err != nil {

--- a/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -301,9 +301,8 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 			return false, err
 		}
 
-		// clean up operand names and image manifests map
+		// clean up operand names
 		config.CleanUpOperandNames()
-		config.CleanUpImageManifests()
 
 		mco.SetFinalizers(util.Remove(mco.GetFinalizers(), resFinalizer))
 		err := r.Client.Update(context.TODO(), mco)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -396,14 +396,6 @@ func SetImageManifests(images map[string]string) {
 	imageManifests = images
 }
 
-// CleanUpImageManifests reset imageManifests
-// Should be called when the MCO CR is deleted
-func CleanUpImageManifests() {
-	for k := range imageManifests {
-		delete(imageManifests, k)
-	}
-}
-
 // ReplaceImage is used to replace the image with specified annotation or imagemanifest configmap
 func ReplaceImage(annotations map[string]string, imageRepo, componentName string) (bool, string) {
 	if annotations != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -396,6 +396,14 @@ func SetImageManifests(images map[string]string) {
 	imageManifests = images
 }
 
+// CleanUpImageManifests reset imageManifests
+// Should be called when the MCO CR is deleted
+func CleanUpImageManifests() {
+	for k := range imageManifests {
+		delete(imageManifests, k)
+	}
+}
+
 // ReplaceImage is used to replace the image with specified annotation or imagemanifest configmap
 func ReplaceImage(annotations map[string]string, imageRepo, componentName string) (bool, string) {
 	if annotations != nil {
@@ -994,4 +1002,12 @@ func SetOperandNames(c client.Client) error {
 	}
 
 	return nil
+}
+
+// CleanUpOperandNames delete all the operand name items
+// Should be called when the MCO CR is deleted
+func CleanUpOperandNames() {
+	for k := range operandNames {
+		delete(operandNames, k)
+	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -892,9 +892,7 @@ func TestGetOperandName(t *testing.T) {
 			componentName: Alertmanager,
 			prepare: func() {
 				//clean the operandNames map
-				for k := range operandNames {
-					delete(operandNames, k)
-				}
+				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
 					ObjectMeta: metav1.ObjectMeta{
@@ -936,9 +934,7 @@ func TestGetOperandName(t *testing.T) {
 			componentName: Alertmanager,
 			prepare: func() {
 				//clean the operandNames map
-				for k := range operandNames {
-					delete(operandNames, k)
-				}
+				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
 					ObjectMeta: metav1.ObjectMeta{
@@ -987,9 +983,7 @@ func TestGetOperandName(t *testing.T) {
 			componentName: Alertmanager,
 			prepare: func() {
 				//clean the operandNames map
-				for k := range operandNames {
-					delete(operandNames, k)
-				}
+				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Signed-off-by: morvencao <lcao@redhat.com>

cherrypick https://github.com/open-cluster-management/multicluster-observability-operator/pull/669
/hold