### PR TITLE
Add debug information for troubleshooting

### DIFF
--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -377,6 +377,7 @@ func ReadImageManifestConfigMap(c client.Client, version string) (bool, error) {
 	}
 
 	imageManifests = imageCMList.Items[0].Data
+	log.V(1).Info("the length of mch-image-manifest configmap", "imageManifests", len(imageManifests))
 	return true, nil
 }
 
@@ -417,9 +418,11 @@ func ReplaceImage(annotations map[string]string, imageRepo, componentName string
 			repoSlice := strings.Split(imageRepo, "/")
 			imageName := strings.Split(repoSlice[len(repoSlice)-1], ":")[0]
 			image := annotationImageRepo + "/" + imageName + ":" + tagSuffix
+			log.V(1).Info("image replacement", "componentName", image)
 			return true, image
 		} else if !hasTagSuffix {
 			image, found := imageManifests[componentName]
+			log.V(1).Info("image replacement", "componentName", image)
 			if found {
 				return true, image
 			}
@@ -428,6 +431,7 @@ func ReplaceImage(annotations map[string]string, imageRepo, componentName string
 		return false, ""
 	} else {
 		image, found := imageManifests[componentName]
+		log.V(1).Info("image replacement", "componentName", image)
 		if found {
 			return true, image
 		}


### PR DESCRIPTION
I found that there are 2 replicasets for `grafana` `rbac-query-proxy` component. One rs is using the default image, the other is using the desired image. alertmanager should have the same behaviour. It can be a root cause of https://github.com/open-cluster-management/backlog/issues/14486
so add more debug info to see what happened

Signed-off-by: clyang82 <chuyang@redhat.com>