### PR TITLE
Register debug to http.DefaultServeMux

### DIFF
--- a/operators/pkg/util/util.go
+++ b/operators/pkg/util/util.go
@@ -9,7 +9,11 @@ import (
 )
 
 func RegisterDebugEndpoint(register func(string, http.Handler) error) error {
-	err := register("/debug/pprof", http.HandlerFunc(pprof.Index))
+	err := register("/debug/", http.Handler(http.DefaultServeMux))
+	if err != nil {
+		return err
+	}
+	err = register("/debug/pprof/", http.HandlerFunc(pprof.Index))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If you're not using the default mux you just have to register any/all of those you want with whatever mux you're using. for our case, we can simply hand off any request prefixed with /debug/ to the http.DefaultServeMux

Signed-off-by: clyang82 <chuyang@redhat.com>