### PR TITLE
fix the clustername key used in hubinfo secret

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -260,7 +260,7 @@ func createManifestWorks(c client.Client, restMapper meta.RESTMapper,
 	manifests = injectIntoWork(manifests, dep)
 
 	// inject the hub info secret
-	hubInfo.Data["clusterName"] = []byte(clusterName)
+	hubInfo.Data[operatorconfig.ClusterNameKey] = []byte(clusterName)
 	manifests = injectIntoWork(manifests, hubInfo)
 
 	if promWorks != nil {


### PR DESCRIPTION
Signed-off-by: Marco <llan@redhat.com>