### PR TITLE
correct managedcluster delete process

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -400,10 +400,12 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c := mgr.GetClient()
 	clusterPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
+			log.Info("CreateFunc", "managedCluster", e.Object.GetName())
 			updateManagedClusterList(e.Object)
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			log.Info("UpdateFunc", "managedCluster", e.ObjectNew.GetName())
 			if e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() {
 				updateManagedClusterList(e.ObjectNew)
 				return true
@@ -411,8 +413,9 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			updateManagedClusterList(e.Object)
-			return e.DeleteStateUnknown
+			log.Info("DeleteFunc", "managedCluster", e.Object.GetName())
+			delete(managedClusterList, e.Object.GetName())
+			return true
 		},
 	}
 

--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -194,15 +194,14 @@ var _ = Describe("Observability:", func() {
 
 	Context("[P2][Sev2][Observability] Should not have the expected MCO addon pods when disable observability from managedcluster (addon/g0) -", func() {
 		It("[Stable] Modifying managedcluster cr to disable observability", func() {
-			Skip("Modifying managedcluster cr to disable observability")
 			Eventually(func() error {
 				return utils.UpdateObservabilityFromManagedCluster(testOptions, false)
 			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 
 			By("Waiting for MCO addon components scales to 0")
 			Eventually(func() bool {
-				_, podList := utils.GetPodList(testOptions, false, MCO_ADDON_NAMESPACE, "component=metrics-collector")
-				if len(podList.Items) == 0 && err == nil {
+				err, obaNS := utils.GetNamespace(testOptions, false, MCO_ADDON_NAMESPACE)
+				if err == nil && obaNS == nil {
 					return true
 				}
 				return false
@@ -210,7 +209,6 @@ var _ = Describe("Observability:", func() {
 		})
 
 		It("[Integration] Modifying managedcluster cr to enable observability", func() {
-			Skip("Modifying managedcluster cr to enable observability")
 			Eventually(func() error {
 				return utils.UpdateObservabilityFromManagedCluster(testOptions, true)
 			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())

--- a/tests/pkg/utils/mco_namespace.go
+++ b/tests/pkg/utils/mco_namespace.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+func GetNamespace(opt TestOptions, isHub bool, namespace string) (error, *v1.Namespace) {
+	clientKube := getKubeClient(opt, isHub)
+
+	ns, err := clientKube.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		klog.Errorf("Failed to get namespace %s due to %v", namespace, err)
+		return err, nil
+	}
+	return nil, ns
+}


### PR DESCRIPTION
if the managedcluster has `observability=disable`, it triggers the `deleteFunc`. so need to remove the cluster name from the map.

Signed-off-by: clyang82 <chuyang@redhat.com>