### PR TITLE
add filter for rbac resources and managedclusteraddon in cache.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/open-cluster-management/multicluster-observability-operator
 go 1.16
 
 require (
-	github.com/IBM/controller-filtered-cache v0.3.2
+	github.com/IBM/controller-filtered-cache v0.3.3
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cloudflare/cfssl v1.6.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
@@ -46,7 +46,6 @@ require (
 )
 
 replace (
-	github.com/IBM/controller-filtered-cache => github.com/morvencao/controller-filtered-cache v0.2.3-0.20210819035548-68e97f281f58
 	github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
 	github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.5
 	github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.5

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 )
 
 replace (
+	github.com/IBM/controller-filtered-cache => github.com/morvencao/controller-filtered-cache v0.2.3-0.20210819035548-68e97f281f58
 	github.com/go-openapi/analysis => github.com/go-openapi/analysis v0.19.5
 	github.com/go-openapi/loads => github.com/go-openapi/loads v0.19.5
 	github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
+github.com/IBM/controller-filtered-cache v0.3.3 h1:B8INm/FDR5akkOBADNzXFdVFLf+8gXtVatcEP8yQvTM=
+github.com/IBM/controller-filtered-cache v0.3.3/go.mod h1:gEDzSQxUwcdScwsw59MTwchTjh6vzLWaSPffIkr85U4=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -1521,8 +1523,6 @@ github.com/monopole/mdrip v1.0.0/go.mod h1:N1/ppRG9CaPeUKAUHZ3dUlfOT81lTpKZLkyhC
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/morvencao/controller-filtered-cache v0.2.3-0.20210819035548-68e97f281f58 h1:Hm9LI4XD0/dHA4S0BsO3cHKv9lvEraunFuELqm6hQ7g=
-github.com/morvencao/controller-filtered-cache v0.2.3-0.20210819035548-68e97f281f58/go.mod h1:gEDzSQxUwcdScwsw59MTwchTjh6vzLWaSPffIkr85U4=
 github.com/mozilla/tls-observatory v0.0.0-20180409132520-8791a200eb40/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mozilla/tls-observatory v0.0.0-20200220173314-aae45faa4006/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,6 @@ github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
-github.com/IBM/controller-filtered-cache v0.3.2 h1:ghyg9s/NyrlyLvZayj65jy4Vcc1dSyD2cee5fp6Ki8Q=
-github.com/IBM/controller-filtered-cache v0.3.2/go.mod h1:gEDzSQxUwcdScwsw59MTwchTjh6vzLWaSPffIkr85U4=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -1523,6 +1521,8 @@ github.com/monopole/mdrip v1.0.0/go.mod h1:N1/ppRG9CaPeUKAUHZ3dUlfOT81lTpKZLkyhC
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/morvencao/controller-filtered-cache v0.2.3-0.20210819035548-68e97f281f58 h1:Hm9LI4XD0/dHA4S0BsO3cHKv9lvEraunFuELqm6hQ7g=
+github.com/morvencao/controller-filtered-cache v0.2.3-0.20210819035548-68e97f281f58/go.mod h1:gEDzSQxUwcdScwsw59MTwchTjh6vzLWaSPffIkr85U4=
 github.com/mozilla/tls-observatory v0.0.0-20180409132520-8791a200eb40/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mozilla/tls-observatory v0.0.0-20200220173314-aae45faa4006/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -352,7 +352,7 @@ func createManagedClusterRes(client client.Client, restMapper meta.RESTMapper,
 		return err
 	}
 
-	err = util.CreateManagedClusterAddonCR(client, namespace)
+	err = util.CreateManagedClusterAddonCR(client, namespace, ownerLabelKey, ownerLabelValue)
 	if err != nil {
 		log.Error(err, "Failed to create ManagedClusterAddon")
 		return err

--- a/operators/multiclusterobservability/controllers/placementrule/role.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role.go
@@ -56,7 +56,7 @@ func createClusterRole(c client.Client) error {
 	}
 
 	found := &rbacv1.ClusterRole{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: mcoRoleName, Namespace: ""}, found)
+	err := c.Get(context.TODO(), types.NamespacedName{Name: mcoRoleName}, found)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info("Creating mco clusterRole")
 		err = c.Create(context.TODO(), role)
@@ -108,7 +108,7 @@ func createClusterRoleBinding(c client.Client, namespace string, name string) er
 	}
 	found := &rbacv1.ClusterRoleBinding{}
 	err := c.Get(context.TODO(), types.NamespacedName{Name: namespace + "-" +
-		mcoRoleBindingName, Namespace: ""}, found)
+		mcoRoleBindingName}, found)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info("Creating endpoint-observability-mco-rolebinding clusterrolebinding")
 		err = c.Create(context.TODO(), rb)
@@ -211,7 +211,7 @@ func createResourceRole(c client.Client) error {
 	}
 
 	found := &rbacv1.ClusterRole{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: resRoleName, Namespace: ""}, found)
+	err := c.Get(context.TODO(), types.NamespacedName{Name: resRoleName}, found)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info("Creating endpoint-observability-res-role clusterrole")
 		err = c.Create(context.TODO(), role)

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -192,7 +192,7 @@ func main() {
 		}
 	}
 
-	// The following RBAC resources will not be weatched by MCO, the selector will not impact the mco behaviour, which means
+	// The following RBAC resources will not be watched by MCO, the selector will not impact the mco behaviour, which means
 	// MCO will fetch kube-apiserver for the correspoding resource if the resource can't be found in the cache.
 	// Adding selector will reduce the cache size when the managedcluster scale.
 	gvkLabelsMap[rbacv1.SchemeGroupVersion.WithKind("ClusterRole")] = []filteredcache.Selector{
@@ -205,6 +205,11 @@ func main() {
 		{LabelSelector: "owner==multicluster-observability-operator"},
 	}
 	gvkLabelsMap[rbacv1.SchemeGroupVersion.WithKind("RoleBinding")] = []filteredcache.Selector{
+		{LabelSelector: "owner==multicluster-observability-operator"},
+	}
+
+	// Add filter for ManagedClusterAddOn to reduce the cache size when the managedclusters scale.
+	gvkLabelsMap[addonv1alpha1.SchemeGroupVersion.WithKind("ManagedClusterAddOn")] = []filteredcache.Selector{
 		{LabelSelector: "owner==multicluster-observability-operator"},
 	}
 

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -33,7 +33,8 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -153,18 +154,18 @@ func main() {
 
 	mcoNamespace := config.GetMCONamespace()
 	gvkLabelsMap := map[schema.GroupVersionKind][]filteredcache.Selector{
-		v1.SchemeGroupVersion.WithKind("Secret"): []filteredcache.Selector{
+		corev1.SchemeGroupVersion.WithKind("Secret"): []filteredcache.Selector{
 			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.OpenshiftIngressOperatorNamespace)},
 			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.OpenshiftIngressNamespace)},
 		},
-		v1.SchemeGroupVersion.WithKind("ConfigMap"): []filteredcache.Selector{
+		corev1.SchemeGroupVersion.WithKind("ConfigMap"): []filteredcache.Selector{
 			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
-		v1.SchemeGroupVersion.WithKind("Service"): []filteredcache.Selector{
+		corev1.SchemeGroupVersion.WithKind("Service"): []filteredcache.Selector{
 			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
-		v1.SchemeGroupVersion.WithKind("ServiceAccount"): []filteredcache.Selector{
+		corev1.SchemeGroupVersion.WithKind("ServiceAccount"): []filteredcache.Selector{
 			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", config.GetDefaultNamespace())},
 		},
 		appsv1.SchemeGroupVersion.WithKind("Deployment"): []filteredcache.Selector{
@@ -189,6 +190,22 @@ func main() {
 		gvkLabelsMap[mchv1.SchemeGroupVersion.WithKind("MultiClusterHub")] = []filteredcache.Selector{
 			{FieldSelector: fmt.Sprintf("metadata.namespace==%s", mcoNamespace)},
 		}
+	}
+
+	// The following RBAC resources will not be weatched by MCO, the selector will not impact the mco behaviour, which means
+	// MCO will fetch kube-apiserver for the correspoding resource if the resource can't be found in the cache.
+	// Adding selector will reduce the cache size when the managedcluster scale.
+	gvkLabelsMap[rbacv1.SchemeGroupVersion.WithKind("ClusterRole")] = []filteredcache.Selector{
+		{LabelSelector: "owner==multicluster-observability-operator"},
+	}
+	gvkLabelsMap[rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding")] = []filteredcache.Selector{
+		{LabelSelector: "owner==multicluster-observability-operator"},
+	}
+	gvkLabelsMap[rbacv1.SchemeGroupVersion.WithKind("Role")] = []filteredcache.Selector{
+		{LabelSelector: "owner==multicluster-observability-operator"},
+	}
+	gvkLabelsMap[rbacv1.SchemeGroupVersion.WithKind("RoleBinding")] = []filteredcache.Selector{
+		{LabelSelector: "owner==multicluster-observability-operator"},
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
+++ b/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
@@ -24,7 +24,7 @@ var (
 	spokeNameSpace = os.Getenv("SPOKE_NAMESPACE")
 )
 
-func CreateManagedClusterAddonCR(c client.Client, namespace string) error {
+func CreateManagedClusterAddonCR(c client.Client, namespace, labelKey, labelValue string) error {
 	newManagedClusterAddon := &addonv1alpha1.ManagedClusterAddOn{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: addonv1alpha1.SchemeGroupVersion.String(),
@@ -33,6 +33,9 @@ func CreateManagedClusterAddonCR(c client.Client, namespace string) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ManagedClusterAddonName,
 			Namespace: namespace,
+			Labels: map[string]string{
+				labelKey: labelValue,
+			},
 		},
 		Spec: addonv1alpha1.ManagedClusterAddOnSpec{
 			InstallNamespace: spokeNameSpace,

--- a/operators/multiclusterobservability/pkg/util/managedclusteraddon_test.go
+++ b/operators/multiclusterobservability/pkg/util/managedclusteraddon_test.go
@@ -23,7 +23,7 @@ func TestManagedClusterAddon(t *testing.T) {
 	s := scheme.Scheme
 	addonv1alpha1.AddToScheme(s)
 	c := fake.NewFakeClient()
-	err := CreateManagedClusterAddonCR(c, namespace)
+	err := CreateManagedClusterAddonCR(c, namespace, "testKey", "value")
 	if err != nil {
 		t.Fatalf("Failed to create managedclusteraddon: (%v)", err)
 	}


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/14774

### Add filter for rbac resources(ClusterRole, ClusterRoleBinding, Role and RoleBinding)

in 2000 simulated manifestwork and 2000 simulated managedcluster env:

before:
```
# kubectl -n open-cluster-management top pod -l name=multicluster-observability-operator
NAME                                                  CPU(cores)   MEMORY(bytes)
multicluster-observability-operator-cd77d999f-xs5bc   20m           805Mi
```

After: 
```
# kubectl -n open-cluster-management top pod -l name=multicluster-observability-operator
NAME                                                   CPU(cores)   MEMORY(bytes)
multicluster-observability-operator-86755cb7b4-q7rdn   12m          562Mi
```
![image](https://user-images.githubusercontent.com/5468682/129708888-bcf1f6ef-1288-44b6-9577-e18af0ca5e09.png)


Signed-off-by: morvencao <lcao@redhat.com>