### PR TITLE
add POD_NAMESPACE environment and check ResourceVersion

### DIFF
--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -112,6 +112,9 @@ func newKubeInformer(coreClient corev1client.CoreV1Interface) cache.SharedIndexI
 			updateDashboard(nil, obj, false)
 		},
 		UpdateFunc: func(old, new interface{}) {
+			if old.(*corev1.ConfigMap).ObjectMeta.ResourceVersion == new.(*corev1.ConfigMap).ObjectMeta.ResourceVersion {
+				return
+			}
 			if !isDesiredDashboardConfigmap(new) {
 				return
 			}

--- a/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
@@ -64,6 +64,11 @@ spec:
         - mountPath: /etc/grafana
           name: grafana-config
       - name: grafana-dashboard-loader
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/open-cluster-management/grafana-dashboard-loader:2.3.0-SNAPSHOT-2021-07-26-18-43-26
         imagePullPolicy: Always
         resources:


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/13382

2 fixes for this issue:
1. pass the `POD_NAMESPACE` environment variable to grafana dashboard loader to watch this namespace configmap only
2. update the grafana dashboards if the resourceVersion is changed.

before:
```
observability-grafana-5d5f6dfffd-j77j2                     grafana-dashboard-loader    5m           220Mi
observability-grafana-5d5f6dfffd-z2f7p                     grafana-dashboard-loader    18m          115Mi
```
after
```
observability-grafana-585d8855b5-89fcq                     grafana-dashboard-loader    0m           16Mi
observability-grafana-585d8855b5-fsdk9                     grafana-dashboard-loader    0m           14Mi
```

Signed-off-by: clyang82 <chuyang@redhat.com>