### PR TITLE
updated sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=open-cluster-management_multicluster-monitoring-operator
-sonar.projectName=multicluster-monitoring-operator
+sonar.projectKey=open-cluster-management_multicluster-observability-operator
+sonar.projectName=multicluster-observability-operator
 sonar.sources=.
 sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**
 sonar.tests=.


### PR DESCRIPTION
Updating the sonar-project.properties `name` and `key` to match the repo name. This was causing the builds to fail with sonar, since the repo was renamed.

Signed-off-by: dislbenn lavontae.bennett@gmail.com / dbennett@redhat.com