### PR TITLE
optimize template load and render.

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	mcov1beta2 "github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
-	placemengctrl "github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/controllers/placementrule"
+	placementctrl "github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/controllers/placementrule"
 	"github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/pkg/certificates"
 	certctrl "github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/pkg/certificates"
 	"github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -114,7 +114,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 
 	if os.Getenv("UNIT_TEST") != "true" {
 		// start placement controller
-		err := placemengctrl.StartPlacementController(r.Manager, r.CRDMap)
+		err := placementctrl.StartPlacementController(r.Manager, r.CRDMap)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -165,7 +165,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	instance.Spec.StorageConfig.StorageClass = storageClassSelected
 	//Render the templates with a specified CR
 	renderer := rendering.NewRenderer(instance)
-	toDeploy, err := renderer.Render(r.Client)
+	toDeploy, err := renderer.Render()
 	if err != nil {
 		reqLogger.Error(err, "Failed to render multiClusterMonitoring templates")
 		return ctrl.Result{}, err

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -36,6 +36,7 @@ import (
 	mcoshared "github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
 	mcov1beta2 "github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/pkg/rendering/templates"
 )
 
 func init() {
@@ -597,6 +598,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 	testManifestsPath := path.Join(wd, "../../tests/manifests")
 	manifestsPath := path.Join(wd, "../../manifests")
 	os.Setenv("TEMPLATES_PATH", testManifestsPath)
+	templates.GetTemplateRenderer().ResetTemplates()
 	err = os.Symlink(manifestsPath, testManifestsPath)
 	if err != nil {
 		t.Fatalf("Failed to create symbollink(%s) to(%s) for the test manifests: (%v)", testManifestsPath, manifestsPath, err)

--- a/operators/multiclusterobservability/controllers/placementrule/endpoint_metrics_operator.go
+++ b/operators/multiclusterobservability/controllers/placementrule/endpoint_metrics_operator.go
@@ -25,17 +25,12 @@ const (
 	rolebindingName = "open-cluster-management:endpoint-observability-operator-rb"
 )
 
-var (
-	templatePath     = "/usr/local/manifests/endpoint-observability"
-	promTemplatePath = "/usr/local/manifests/prometheus"
-)
-
+// loadTemplates load manifests from manifests directory
 func loadTemplates(mco *mcov1beta2.MultiClusterObservability) (
 	[]runtime.RawExtension, *apiextensionsv1.CustomResourceDefinition,
 	*apiextensionsv1beta1.CustomResourceDefinition, *appsv1.Deployment, error) {
-	templateRenderer := templates.NewTemplateRenderer(templatePath)
-	resourceList := []*resource.Resource{}
-	err := templateRenderer.AddTemplateFromPath(templatePath, &resourceList)
+	// render endpoint-observability templates
+	endpointObsTemplates, err := templates.GetTemplateRenderer().GetOrLoadEndpointObservabilityTemplates()
 	if err != nil {
 		log.Error(err, "Failed to load templates")
 		return nil, nil, nil, nil, err
@@ -44,7 +39,7 @@ func loadTemplates(mco *mcov1beta2.MultiClusterObservability) (
 	crdv1beta1 := &apiextensionsv1beta1.CustomResourceDefinition{}
 	dep := &appsv1.Deployment{}
 	rawExtensionList := []runtime.RawExtension{}
-	for _, r := range resourceList {
+	for _, r := range endpointObsTemplates {
 		obj, err := updateRes(r, mco)
 		if err != nil {
 			return nil, nil, nil, nil, err
@@ -136,15 +131,14 @@ func getImage(mco *mcov1beta2.MultiClusterObservability,
 
 func loadPromTemplates(mco *mcov1beta2.MultiClusterObservability) (
 	[]runtime.RawExtension, error) {
-	templateRenderer := templates.NewTemplateRenderer(promTemplatePath)
-	resourceList := []*resource.Resource{}
-	err := templateRenderer.AddTemplateFromPath(promTemplatePath, &resourceList)
+	// load and render promTemplates
+	promTemplates, err := templates.GetTemplateRenderer().GetOrLoadPrometheusTemplates()
 	if err != nil {
 		log.Error(err, "Failed to load templates")
 		return nil, err
 	}
 	rawExtensionList := []runtime.RawExtension{}
-	for _, r := range resourceList {
+	for _, r := range promTemplates {
 		obj, err := updateRes(r, mco)
 		if err != nil {
 			return nil, err

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -157,8 +157,15 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get work dir: (%v)", err)
 	}
-	templatePath = path.Join(wd, "../../manifests/endpoint-observability")
-	promTemplatePath = path.Join(wd, "../../manifests/prometheus")
+
+	os.MkdirAll(path.Join(wd, "../../tests"), 0755)
+	testManifestsPath := path.Join(wd, "../../tests/manifests")
+	manifestsPath := path.Join(wd, "../../manifests")
+	os.Setenv("TEMPLATES_PATH", testManifestsPath)
+	err = os.Symlink(manifestsPath, testManifestsPath)
+	if err != nil {
+		t.Fatalf("Failed to create symbollink(%s) to(%s) for the test manifests: (%v)", testManifestsPath, manifestsPath, err)
+	}
 
 	works, promWorks, crdWork, _, dep, hubInfo, err := getGlobalManifestResources(c, newTestMCO())
 	if err != nil {
@@ -213,6 +220,11 @@ func TestManifestWork(t *testing.T) {
 	if err == nil || !errors.IsNotFound(err) {
 		t.Fatalf("Manifestwork not deleted: (%v)", err)
 	}
+
+	if err = os.Remove(testManifestsPath); err != nil {
+		t.Fatalf("Failed to delete symbollink(%s) for the test manifests: (%v)", testManifestsPath, err)
+	}
+	os.Remove(path.Join(wd, "../../tests"))
 }
 
 func TestMergeMetrics(t *testing.T) {

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -63,7 +63,6 @@ type PlacementRuleReconciler struct {
 	Log        logr.Logger
 	Scheme     *runtime.Scheme
 	CRDMap     map[string]bool
-	APIReader  client.Reader
 	RESTMapper meta.RESTMapper
 }
 
@@ -709,7 +708,6 @@ func StartPlacementController(mgr manager.Manager, crdMap map[string]bool) error
 		Client:     mgr.GetClient(),
 		Log:        ctrl.Log.WithName("controllers").WithName("PlacementRule"),
 		Scheme:     mgr.GetScheme(),
-		APIReader:  mgr.GetAPIReader(),
 		CRDMap:     crdMap,
 		RESTMapper: mgr.GetRESTMapper(),
 	}).SetupWithManager(mgr); err != nil {

--- a/operators/multiclusterobservability/pkg/rendering/renderer_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_test.go
@@ -47,7 +47,7 @@ func TestRender(t *testing.T) {
 	}
 
 	renderer := NewRenderer(mchcr)
-	objs, err := renderer.Render(nil)
+	objs, err := renderer.Render()
 	if err != nil {
 		t.Fatalf("failed to render MultiClusterObservability: %v", err)
 	}

--- a/operators/multiclusterobservability/pkg/rendering/templates/templates.go
+++ b/operators/multiclusterobservability/pkg/rendering/templates/templates.go
@@ -18,14 +18,15 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
-
-	mcov1beta2 "github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 )
 
 const TemplatesPathEnvVar = "TEMPLATES_PATH"
 
 var loadTemplateRendererOnce sync.Once
 var templateRenderer *TemplateRenderer
+
+// *Templates contains all kustomize resources
+var genericTemplates, grafanaTemplates, alertManagerTemplates, thanosTemplates, proxyTemplates, endpointObservabilityTemplates, prometheusTemplates []*resource.Resource
 
 type TemplateRenderer struct {
 	templatesPath string
@@ -53,80 +54,117 @@ func GetTemplateRenderer() *TemplateRenderer {
 	return templateRenderer
 }
 
-// GetGrafanaTemplates reads the grafana manifests
-func (r *TemplateRenderer) GetGrafanaTemplates(
-	mco *mcov1beta2.MultiClusterObservability) ([]*resource.Resource, error) {
-	basePath := path.Join(r.templatesPath, "base")
-	// resourceList contains all kustomize resources
-	resourceList := []*resource.Resource{}
-
-	// add grafana template
-	if err := r.AddTemplateFromPath(basePath+"/grafana", &resourceList); err != nil {
-		return resourceList, err
+// GetOrLoadGenericTemplates reads base manifest
+func (r *TemplateRenderer) GetOrLoadGenericTemplates() ([]*resource.Resource, error) {
+	if len(genericTemplates) > 0 {
+		return genericTemplates, nil
 	}
-	return resourceList, nil
-}
 
-// GetAlertManagerTemplates reads the alertmanager manifests
-func (r *TemplateRenderer) GetAlertManagerTemplates(
-	mco *mcov1beta2.MultiClusterObservability) ([]*resource.Resource, error) {
 	basePath := path.Join(r.templatesPath, "base")
-	// resourceList contains all kustomize resources
-	resourceList := []*resource.Resource{}
-
-	// add alertmanager template
-	if err := r.AddTemplateFromPath(basePath+"/alertmanager", &resourceList); err != nil {
-		return resourceList, err
-	}
-	return resourceList, nil
-}
-
-// GetThanosTemplates reads the thanos manifests
-func (r *TemplateRenderer) GetThanosTemplates(
-	mco *mcov1beta2.MultiClusterObservability) ([]*resource.Resource, error) {
-	basePath := path.Join(r.templatesPath, "base")
-	// resourceList contains all kustomize resources
-	resourceList := []*resource.Resource{}
-
-	// add thanos template
-	if err := r.AddTemplateFromPath(basePath+"/thanos", &resourceList); err != nil {
-		return resourceList, err
-	}
-	return resourceList, nil
-}
-
-// GetProxyTemplates reads the rbac-query-proxy manifests
-func (r *TemplateRenderer) GetProxyTemplates(
-	mco *mcov1beta2.MultiClusterObservability) ([]*resource.Resource, error) {
-	basePath := path.Join(r.templatesPath, "base")
-	// resourceList contains all kustomize resources
-	resourceList := []*resource.Resource{}
-
-	// add rbac-query-proxy template
-	if err := r.AddTemplateFromPath(basePath+"/proxy", &resourceList); err != nil {
-		return resourceList, err
-	}
-	return resourceList, nil
-}
-
-// GetTemplates reads base manifest
-func (r *TemplateRenderer) GetTemplates(
-	mco *mcov1beta2.MultiClusterObservability) ([]*resource.Resource, error) {
-	basePath := path.Join(r.templatesPath, "base")
-	// resourceList contains all kustomize resources
-	resourceList := []*resource.Resource{}
 
 	// add observatorium template
-	if err := r.AddTemplateFromPath(basePath+"/observatorium", &resourceList); err != nil {
-		return resourceList, err
+	if err := r.AddTemplateFromPath(basePath+"/observatorium", &genericTemplates); err != nil {
+		return genericTemplates, err
 	}
 
 	// add config template
-	if err := r.AddTemplateFromPath(basePath+"/config", &resourceList); err != nil {
-		return resourceList, err
+	if err := r.AddTemplateFromPath(basePath+"/config", &genericTemplates); err != nil {
+		return genericTemplates, err
 	}
 
-	return resourceList, nil
+	return genericTemplates, nil
+}
+
+// GetOrLoadGrafanaTemplates reads the grafana manifests
+func (r *TemplateRenderer) GetOrLoadGrafanaTemplates() ([]*resource.Resource, error) {
+	if len(grafanaTemplates) > 0 {
+		return grafanaTemplates, nil
+	}
+
+	basePath := path.Join(r.templatesPath, "base")
+
+	// add grafana template
+	if err := r.AddTemplateFromPath(basePath+"/grafana", &grafanaTemplates); err != nil {
+		return grafanaTemplates, err
+	}
+	return grafanaTemplates, nil
+}
+
+// GetOrLoadAlertManagerTemplates reads the alertmanager manifests
+func (r *TemplateRenderer) GetOrLoadAlertManagerTemplates() ([]*resource.Resource, error) {
+	if len(alertManagerTemplates) > 0 {
+		return alertManagerTemplates, nil
+	}
+
+	basePath := path.Join(r.templatesPath, "base")
+
+	// add alertmanager template
+	if err := r.AddTemplateFromPath(basePath+"/alertmanager", &alertManagerTemplates); err != nil {
+		return alertManagerTemplates, err
+	}
+	return alertManagerTemplates, nil
+}
+
+// GetOrLoadThanosTemplates reads the thanos manifests
+func (r *TemplateRenderer) GetOrLoadThanosTemplates() ([]*resource.Resource, error) {
+	if len(thanosTemplates) > 0 {
+		return thanosTemplates, nil
+	}
+
+	basePath := path.Join(r.templatesPath, "base")
+
+	// add thanos template
+	if err := r.AddTemplateFromPath(basePath+"/thanos", &thanosTemplates); err != nil {
+		return thanosTemplates, err
+	}
+	return thanosTemplates, nil
+}
+
+// GetOrLoadProxyTemplates reads the rbac-query-proxy manifests
+func (r *TemplateRenderer) GetOrLoadProxyTemplates() ([]*resource.Resource, error) {
+	if len(proxyTemplates) > 0 {
+		return proxyTemplates, nil
+	}
+
+	basePath := path.Join(r.templatesPath, "base")
+
+	// add rbac-query-proxy template
+	if err := r.AddTemplateFromPath(basePath+"/proxy", &proxyTemplates); err != nil {
+		return proxyTemplates, err
+	}
+	return proxyTemplates, nil
+}
+
+// GetEndpointObservabilityTemplates reads endpoint-observability manifest
+func (r *TemplateRenderer) GetOrLoadEndpointObservabilityTemplates() ([]*resource.Resource, error) {
+	if len(endpointObservabilityTemplates) > 0 {
+		return endpointObservabilityTemplates, nil
+	}
+
+	basePath := path.Join(r.templatesPath, "endpoint-observability")
+
+	// add endpoint ovservability template
+	if err := r.AddTemplateFromPath(basePath, &endpointObservabilityTemplates); err != nil {
+		return endpointObservabilityTemplates, err
+	}
+
+	return endpointObservabilityTemplates, nil
+}
+
+// GetOrLoadPrometheusTemplates reads endpoint-observability manifest
+func (r *TemplateRenderer) GetOrLoadPrometheusTemplates() ([]*resource.Resource, error) {
+	if len(prometheusTemplates) > 0 {
+		return prometheusTemplates, nil
+	}
+
+	basePath := path.Join(r.templatesPath, "prometheus")
+
+	// add endpoint ovservability template
+	if err := r.AddTemplateFromPath(basePath, &prometheusTemplates); err != nil {
+		return prometheusTemplates, err
+	}
+
+	return prometheusTemplates, nil
 }
 
 func (r *TemplateRenderer) AddTemplateFromPath(kustomizationPath string, resourceList *[]*resource.Resource) error {
@@ -168,4 +206,14 @@ func (r *TemplateRenderer) render(kustomizationPath string) (resmap.ResMap, erro
 		return nil, err
 	}
 	return kt.MakeCustomizedResMap()
+}
+
+// ResetTemplates reset all the loaded templates
+func (r *TemplateRenderer) ResetTemplates() {
+	genericTemplates = nil
+	grafanaTemplates = nil
+	alertManagerTemplates = nil
+	thanosTemplates = nil
+	proxyTemplates = nil
+	endpointObservabilityTemplates = nil
 }

--- a/operators/multiclusterobservability/pkg/rendering/templates/templates_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/templates/templates_test.go
@@ -7,13 +7,9 @@ import (
 	"os"
 	"path"
 	"testing"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	mcov1beta2 "github.com/open-cluster-management/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 )
 
-func TestGetCoreTemplates(t *testing.T) {
+func TestGetOrLoadCoreTemplates(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed to get working dir %v", err)
@@ -22,18 +18,7 @@ func TestGetCoreTemplates(t *testing.T) {
 	os.Setenv(TemplatesPathEnvVar, templatesPath)
 	defer os.Unsetenv(TemplatesPathEnvVar)
 
-	mchcr := &mcov1beta2.MultiClusterObservability{
-		TypeMeta:   metav1.TypeMeta{Kind: "MultiClusterObservability"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"},
-		Spec: mcov1beta2.MultiClusterObservabilitySpec{
-			ImagePullPolicy: "Always",
-			ImagePullSecret: "test",
-			StorageConfig: &mcov1beta2.StorageConfig{
-				StorageClass: "gp2",
-			},
-		},
-	}
-	_, err = GetTemplateRenderer().GetTemplates(mchcr)
+	_, err = GetTemplateRenderer().GetOrLoadGenericTemplates()
 
 	if err != nil {
 		t.Fatalf("failed to render core template %v", err)


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/14774

This PR tries to optimize the manifests loading with kustimize library:
- loading manifests from disk with kustomize library is an expensive operation and the load results will never change, so we just need to load once.
- some other small fixes, mainly removing unused parameters.

In simulated env of 2k manifestwork + 2k managedcluster, the highest memory usage before this change:

```
# kubectl -n open-cluster-management top pod -l name=multicluster-observability-operator
NAME                                                   CPU(cores)   MEMORY(bytes)
multicluster-observability-operator-5547d89bcc-vh2rp   7m           827Mi
```

After this change, the memory is:

```
# kubectl -n open-cluster-management top pod -l name=multicluster-observability-operator
NAME                                                   CPU(cores)   MEMORY(bytes)
multicluster-observability-operator-7d889cf999-ctgv4   5m           596Mi
```

Note: the results shown here are not strictly correct, since after I replaced the image, the reconcile loop stopped for env reason, the resource usage would also be impacted.

Signed-off-by: morvencao <lcao@redhat.com>