### PR TITLE
fix update logic for managedclusteraddon.

### DIFF
--- a/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
+++ b/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
@@ -68,6 +68,7 @@ func CreateManagedClusterAddonCR(c client.Client, namespace string) error {
 		managedClusterAddon,
 	); err != nil && errors.IsNotFound(err) {
 		// create new managedClusterAddon
+		log.Info("Creating managedClusterAddon", "name", ManagedClusterAddonName, "namespace", namespace)
 		if err := c.Create(context.TODO(), newManagedClusterAddon); err != nil {
 			log.Error(err, "Cannot create observability-controller  ManagedClusterAddOn")
 			return err
@@ -79,20 +80,20 @@ func CreateManagedClusterAddonCR(c client.Client, namespace string) error {
 	} else if err != nil {
 		log.Error(err, "Failed to get ManagedClusterAddOn ", "namespace", namespace)
 		return err
-	}
-
-	if !reflect.DeepEqual(managedClusterAddon.Spec, newManagedClusterAddon.Spec) {
-		log.Info("Updating observability-controller managedClusterAddon")
-		newManagedClusterAddon.ObjectMeta.ResourceVersion = managedClusterAddon.ObjectMeta.ResourceVersion
-		err := c.Update(context.TODO(), newManagedClusterAddon)
-		if err != nil {
-			log.Error(err, "Failed to update observability-controller managedClusterAddon")
-			return err
+	} else {
+		if !reflect.DeepEqual(managedClusterAddon.Spec, newManagedClusterAddon.Spec) {
+			log.Info("Updating managedClusterAddon", "name", ManagedClusterAddonName, "namespace", namespace)
+			newManagedClusterAddon.ObjectMeta.ResourceVersion = managedClusterAddon.ObjectMeta.ResourceVersion
+			err := c.Update(context.TODO(), newManagedClusterAddon)
+			if err != nil {
+				log.Error(err, "Failed to update observability-controller managedClusterAddon")
+				return err
+			}
+			return nil
 		}
-		return nil
 	}
 
-	log.Info("ManagedClusterAddOn already present", "namespace", namespace)
+	log.Info("ManagedClusterAddOn is created or updated successfully", "name", ManagedClusterAddonName, "namespace", namespace)
 
 	return nil
 }

--- a/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
+++ b/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,25 +38,6 @@ func CreateManagedClusterAddonCR(c client.Client, namespace string) error {
 		Spec: addonv1alpha1.ManagedClusterAddOnSpec{
 			InstallNamespace: spokeNameSpace,
 		},
-		Status: addonv1alpha1.ManagedClusterAddOnStatus{
-			AddOnConfiguration: addonv1alpha1.ConfigCoordinates{
-				CRDName: "observabilityaddons.observability.open-cluster-management.io",
-				CRName:  "observability-addon",
-			},
-			AddOnMeta: addonv1alpha1.AddOnMeta{
-				DisplayName: "Observability Controller",
-				Description: "Manages Observability components.",
-			},
-			Conditions: []metav1.Condition{
-				{
-					Type:               "Progressing",
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: metav1.NewTime(time.Now()),
-					Reason:             "ManifestWorkCreated",
-					Message:            "Addon Installing",
-				},
-			},
-		},
 	}
 	managedClusterAddon := &addonv1alpha1.ManagedClusterAddOn{}
 	// check if managedClusterAddon exists
@@ -68,32 +50,80 @@ func CreateManagedClusterAddonCR(c client.Client, namespace string) error {
 		managedClusterAddon,
 	); err != nil && errors.IsNotFound(err) {
 		// create new managedClusterAddon
-		log.Info("Creating managedClusterAddon", "name", ManagedClusterAddonName, "namespace", namespace)
 		if err := c.Create(context.TODO(), newManagedClusterAddon); err != nil {
-			log.Error(err, "Cannot create observability-controller  ManagedClusterAddOn")
+			log.Error(err, "failed to create managedclusteraddon", "name", ManagedClusterAddonName, "namespace", namespace)
 			return err
 		}
-		if err := c.Status().Update(context.TODO(), newManagedClusterAddon); err != nil {
-			log.Error(err, "Cannot update status for observability-controller  ManagedClusterAddOn")
-			return err
-		}
-	} else if err != nil {
-		log.Error(err, "Failed to get ManagedClusterAddOn ", "namespace", namespace)
-		return err
-	} else {
-		if !reflect.DeepEqual(managedClusterAddon.Spec, newManagedClusterAddon.Spec) {
-			log.Info("Updating managedClusterAddon", "name", ManagedClusterAddonName, "namespace", namespace)
-			newManagedClusterAddon.ObjectMeta.ResourceVersion = managedClusterAddon.ObjectMeta.ResourceVersion
-			err := c.Update(context.TODO(), newManagedClusterAddon)
-			if err != nil {
-				log.Error(err, "Failed to update observability-controller managedClusterAddon")
-				return err
+
+		// wait 10s for the created managedclusteraddon ready
+		if errPoll := wait.Poll(2*time.Second, 10*time.Second, func() (bool, error) {
+			if err := c.Get(
+				context.TODO(),
+				types.NamespacedName{
+					Name:      ManagedClusterAddonName,
+					Namespace: namespace,
+				},
+				managedClusterAddon,
+			); err == nil {
+				return true, nil
 			}
-			return nil
+			return false, err
+		}); errPoll != nil {
+			log.Error(errPoll, "failed to get the created managedclusteraddon", "name", ManagedClusterAddonName, "namespace", namespace)
+			return errPoll
 		}
+
+		// got the created managedclusteraddon just now, uopdating its status
+		managedClusterAddon.Status.AddOnConfiguration = addonv1alpha1.ConfigCoordinates{
+			CRDName: "observabilityaddons.observability.open-cluster-management.io",
+			CRName:  "observability-addon",
+		}
+		managedClusterAddon.Status.AddOnMeta = addonv1alpha1.AddOnMeta{
+			DisplayName: "Observability Controller",
+			Description: "Manages Observability components.",
+		}
+		if len(managedClusterAddon.Status.Conditions) > 0 {
+			managedClusterAddon.Status.Conditions = append(managedClusterAddon.Status.Conditions, metav1.Condition{
+				Type:               "Progressing",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now()),
+				Reason:             "ManifestWorkCreated",
+				Message:            "Addon Installing",
+			})
+		} else {
+			managedClusterAddon.Status.Conditions = []metav1.Condition{
+				{
+					Type:               "Progressing",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now()),
+					Reason:             "ManifestWorkCreated",
+					Message:            "Addon Installing",
+				},
+			}
+		}
+		// update status for the created managedclusteraddon
+		if err := c.Status().Update(context.TODO(), managedClusterAddon); err != nil {
+			log.Error(err, "failed to update status for managedclusteraddon", "name", ManagedClusterAddonName, "namespace", namespace)
+			return err
+		}
+		return nil
+	} else if err != nil {
+		log.Error(err, "failed to get managedclusteraddon", "name", ManagedClusterAddonName, "namespace", namespace)
+		return err
+	}
+
+	// managedclusteraddon already exists, updating...
+	if !reflect.DeepEqual(managedClusterAddon.Spec, newManagedClusterAddon.Spec) {
+		log.Info("found difference, updating managedClusterAddon", "name", ManagedClusterAddonName, "namespace", namespace)
+		newManagedClusterAddon.ObjectMeta.ResourceVersion = managedClusterAddon.ObjectMeta.ResourceVersion
+		err := c.Update(context.TODO(), newManagedClusterAddon)
+		if err != nil {
+			log.Error(err, "failed to update managedclusteraddon", "name", ManagedClusterAddonName, "namespace", namespace)
+			return err
+		}
+		return nil
 	}
 
 	log.Info("ManagedClusterAddOn is created or updated successfully", "name", ManagedClusterAddonName, "namespace", namespace)
-
 	return nil
 }


### PR DESCRIPTION
ref: open-cluster-management/backlog#14774

This PR fixes the **update** logic for **managedclusteraddon** resource, the **update** logic should in different reconcile loop with **create** logic, otherwise we always get the following error:

```
{"level":"error","ts":1629431004.136965,"logger":"controller_placementrule","msg":"Failed to create ManagedClusterAddon","error":"managedclusteraddons.addon.open-cluster-management.io \"observability-controller\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update","stacktrace":"github.com/open-cluster-management/multicluster-observability-operator/controllers/placementrule.createManagedClusterRes\n\t/root/workspace/multicluster-observability-operator-release-23/controllers/placementrule/placementrule_controller.go:412
```

Signed-off-by: morvencao <lcao@redhat.com>