### PR TITLE
replace route in kind testing env.

### DIFF
--- a/examples/minio/minio-deployment.yaml
+++ b/examples/minio/minio-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           value: minio
         - name: MINIO_SECRET_KEY
           value: minio123
-        image:  minio/minio:latest
+        image:  quay.io/minio/minio:RELEASE.2021-08-25T00-41-18Z
         name: minio
         ports:
         - containerPort: 9000

--- a/examples/minio/minio-pvc.yaml
+++ b/examples/minio/minio-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   name: minio
   namespace: open-cluster-management-observability
 spec:
-  storageClassName: gp2
+  storageClassName: standard
   accessModes:
   - ReadWriteOnce
   resources:

--- a/examples/minio/minio-pvc.yaml
+++ b/examples/minio/minio-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   name: minio
   namespace: open-cluster-management-observability
 spec:
-  storageClassName: standard
+  storageClassName: gp2
   accessModes:
   - ReadWriteOnce
   resources:

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -200,22 +200,28 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	// expose alertmanager through route
-	result, err = GenerateAlertmanagerRoute(r.Client, r.Scheme, instance)
-	if result != nil {
-		return *result, err
-	}
+	// the route resource won't be created in testing env, for instance, KinD
+	// in the testing env, the service can be accessed via service name, we assume that
+	// in testing env, the local-cluster is the only allowed managedcluster
+	ingressCtlCrdExists, _ := r.CRDMap[config.IngressControllerCRD]
+	if ingressCtlCrdExists {
+		// expose alertmanager through route
+		result, err = GenerateAlertmanagerRoute(r.Client, r.Scheme, instance)
+		if result != nil {
+			return *result, err
+		}
 
-	// expose observatorium api gateway
-	result, err = GenerateAPIGatewayRoute(r.Client, r.Scheme, instance)
-	if result != nil {
-		return *result, err
-	}
+		// expose observatorium api gateway
+		result, err = GenerateAPIGatewayRoute(r.Client, r.Scheme, instance)
+		if result != nil {
+			return *result, err
+		}
 
-	// expose rbac proxy through route
-	result, err = GenerateProxyRoute(r.Client, r.Scheme, instance)
-	if result != nil {
-		return *result, err
+		// expose rbac proxy through route
+		result, err = GenerateProxyRoute(r.Client, r.Scheme, instance)
+		if result != nil {
+			return *result, err
+		}
 	}
 
 	// create the certificates

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -113,6 +113,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	// start to update mco status
 	StartStatusUpdate(r.Client, instance)
 
+	ingressCtlCrdExists, _ := r.CRDMap[config.IngressControllerCRD]
 	if os.Getenv("UNIT_TEST") != "true" {
 		// start placement controller
 		err := placementctrl.StartPlacementController(r.Manager, r.CRDMap)
@@ -120,7 +121,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 			return ctrl.Result{}, err
 		}
 		// setup ocm addon manager
-		certctrl.Start(r.Client)
+		certctrl.Start(r.Client, ingressCtlCrdExists)
 	}
 
 	// Init finalizers
@@ -203,7 +204,6 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	// the route resource won't be created in testing env, for instance, KinD
 	// in the testing env, the service can be accessed via service name, we assume that
 	// in testing env, the local-cluster is the only allowed managedcluster
-	ingressCtlCrdExists, _ := r.CRDMap[config.IngressControllerCRD]
 	if ingressCtlCrdExists {
 		// expose alertmanager through route
 		result, err = GenerateAlertmanagerRoute(r.Client, r.Scheme, instance)
@@ -225,7 +225,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// create the certificates
-	err = certificates.CreateObservabilityCerts(r.Client, r.Scheme, instance)
+	err = certificates.CreateObservabilityCerts(r.Client, r.Scheme, instance, ingressCtlCrdExists)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -59,7 +59,7 @@ func newTestCert(name string, namespace string) *corev1.Secret {
 
 var testImagemanifestsMap = map[string]string{
 	"endpoint_monitoring_operator": "test.io/endpoint-monitoring:test",
-	"grafana":                      "test.io/grafana:test",
+	"grafana":                      "test.io/origin-grafana:test",
 	"grafana_dashboard_loader":     "test.io/grafana-dashboard-loader:test",
 	"management_ingress":           "test.io/management-ingress:test",
 	"observatorium":                "test.io/observatorium:test",
@@ -709,7 +709,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 				t.Fatalf("The image key(%s) for the container(%s) doesn't exist in the deployment(%s)", imageKey, container.Name, deployName)
 			}
 			if imageValue != container.Image {
-				t.Fatalf("The image(%s) for the container(%s) in the deployment(%s) should not replace with the one in the image manifests", imageValue, container.Name, deployName)
+				t.Fatalf("The image(%s) for the container(%s) in the deployment(%s) should be replaced with the one(%s) in the image manifests", container.Image, container.Name, deployName, imageValue)
 			}
 		}
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -327,7 +327,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 
 	// Create a ReconcileMemcached object with the scheme and fake client.
-	r := &MultiClusterObservabilityReconciler{Client: cl, Scheme: s, CRDMap: map[string]bool{}}
+	r := &MultiClusterObservabilityReconciler{Client: cl, Scheme: s, CRDMap: map[string]bool{config.IngressControllerCRD: true}}
 	config.SetMonitoringCRName(name)
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .
@@ -658,7 +658,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 
 	// Create a ReconcileMemcached object with the scheme and fake client.
-	r := &MultiClusterObservabilityReconciler{Client: cl, Scheme: s, CRDMap: map[string]bool{config.MCHCrdName: true}}
+	r := &MultiClusterObservabilityReconciler{Client: cl, Scheme: s, CRDMap: map[string]bool{config.MCHCrdName: true, config.IngressControllerCRD: true}}
 	config.SetMonitoringCRName(name)
 
 	// Mock request to simulate Reconcile() being called on an event for a watched resource .

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
@@ -112,7 +112,7 @@ func TestNewSecret(t *testing.T) {
 	objs := []runtime.Object{newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret()}
 	c := fake.NewFakeClient(objs...)
 
-	hubInfo, err := generateHubInfoSecret(c, mcoNamespace, namespace)
+	hubInfo, err := generateHubInfoSecret(c, mcoNamespace, namespace, true)
 	if err != nil {
 		t.Fatalf("Failed to initial the hub info secret: (%v)", err)
 	}
@@ -132,7 +132,7 @@ func TestNewBYOSecret(t *testing.T) {
 	objs := []runtime.Object{newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestAmRouteBYOCA(), newTestAmRouteBYOCert()}
 	c := fake.NewFakeClient(objs...)
 
-	hubInfo, err := generateHubInfoSecret(c, mcoNamespace, namespace)
+	hubInfo, err := generateHubInfoSecret(c, mcoNamespace, namespace, true)
 	if err != nil {
 		t.Fatalf("Failed to initial the hub info secret: (%v)", err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -172,7 +172,7 @@ func TestManifestWork(t *testing.T) {
 		t.Fatalf("Failed to get global manifestwork resourc: (%v)", err)
 	}
 	t.Logf("work size is %d", len(works))
-	if hubInfoSecret, err = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace); err != nil {
+	if hubInfoSecret, err = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, true); err != nil {
 		t.Fatalf("Failed to generate hubInfo secret: (%v)", err)
 	}
 	err = createManifestWorks(c, nil, namespace, clusterName, newTestMCO(), works, crdWork, endpointMetricsOperatorDeploy, hubInfoSecret, false)

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -419,6 +419,7 @@ func updateManagedClusterList(obj client.Object) {
 // SetupWithManager sets up the controller with the Manager.
 func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c := mgr.GetClient()
+	ingressCtlCrdExists, _ := r.CRDMap[config.IngressControllerCRD]
 	clusterPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			log.Info("CreateFunc", "managedCluster", e.Object.GetName())
@@ -562,7 +563,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if e.Object.GetName() == config.OpenshiftIngressOperatorCRName &&
 				e.Object.GetNamespace() == config.OpenshiftIngressOperatorNamespace {
 				// generate the hubInfo secret
-				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace)
+				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, ingressCtlCrdExists)
 				return true
 			}
 			return false
@@ -572,7 +573,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
 				e.ObjectNew.GetNamespace() == config.OpenshiftIngressOperatorNamespace {
 				// regenerate the hubInfo secret
-				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace)
+				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, ingressCtlCrdExists)
 				return true
 			}
 			return false
@@ -581,7 +582,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if e.Object.GetName() == config.OpenshiftIngressOperatorCRName &&
 				e.Object.GetNamespace() == config.OpenshiftIngressOperatorNamespace {
 				// regenerate the hubInfo secret
-				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace)
+				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, ingressCtlCrdExists)
 				return true
 			}
 			return false
@@ -594,7 +595,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				(e.Object.GetName() == config.AlertmanagerRouteBYOCAName ||
 					e.Object.GetName() == config.AlertmanagerRouteBYOCERTName) {
 				// generate the hubInfo secret
-				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace)
+				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, ingressCtlCrdExists)
 				return true
 			}
 			return false
@@ -605,7 +606,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				(e.ObjectNew.GetName() == config.AlertmanagerRouteBYOCAName ||
 					e.ObjectNew.GetName() == config.AlertmanagerRouteBYOCERTName) {
 				// regenerate the hubInfo secret
-				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace)
+				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, ingressCtlCrdExists)
 				return true
 			}
 			return false
@@ -615,7 +616,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				(e.Object.GetName() == config.AlertmanagerRouteBYOCAName ||
 					e.Object.GetName() == config.AlertmanagerRouteBYOCERTName) {
 				// regenerate the hubInfo secret
-				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace)
+				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, ingressCtlCrdExists)
 				return true
 			}
 			return false
@@ -629,7 +630,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				(e.Object.GetNamespace() == config.OpenshiftIngressNamespace &&
 					e.Object.GetName() == config.OpenshiftIngressDefaultCertName) {
 				// generate the hubInfo secret
-				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace)
+				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, ingressCtlCrdExists)
 				return true
 			}
 			return false
@@ -641,7 +642,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					e.ObjectNew.GetName() == config.OpenshiftIngressDefaultCertName)) &&
 				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() {
 				// regenerate the hubInfo secret
-				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace)
+				hubInfoSecret, _ = generateHubInfoSecret(c, config.GetDefaultNamespace(), spokeNameSpace, ingressCtlCrdExists)
 				return true
 			}
 			return false
@@ -752,7 +753,6 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 		}
 
-		ingressCtlCrdExists, _ := r.CRDMap[config.IngressControllerCRD]
 		if ingressCtlCrdExists {
 			// secondary watch for default ingresscontroller
 			ctrBuilder = ctrBuilder.Watches(&source.Kind{Type: &operatorv1.IngressController{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(ingressControllerPred)).

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -83,7 +83,7 @@ func TestObservabilityAddonController(t *testing.T) {
 	objs := []runtime.Object{mco, pull, newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret(), newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
 		NewAmAccessorSA(), NewAmAccessorTokenSecret(), newManagedClusterAddon(), deprecatedRole}
 	c := fake.NewFakeClient(objs...)
-	r := &PlacementRuleReconciler{Client: c, Scheme: s, CRDMap: map[string]bool{}}
+	r := &PlacementRuleReconciler{Client: c, Scheme: s, CRDMap: map[string]bool{config.IngressControllerCRD: true}}
 
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{

--- a/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
       - args:
         - -config=/etc/grafana/grafana.ini
-        image:  grafana/grafana:7.4.2
+        image:  quay.io/openshift/origin-grafana:4.8.0
         imagePullPolicy: Always
         name: grafana
         ports:

--- a/operators/multiclusterobservability/pkg/certificates/cert_controller.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller.go
@@ -36,7 +36,7 @@ var (
 	isCertControllerRunnning = false
 )
 
-func Start(c client.Client) {
+func Start(c client.Client, ingressCtlCrdExists bool) {
 
 	if isCertControllerRunnning {
 		return
@@ -78,7 +78,7 @@ func Start(c client.Client) {
 
 			DeleteFunc: onDelete(c),
 
-			UpdateFunc: onUpdate(c),
+			UpdateFunc: onUpdate(c, ingressCtlCrdExists),
 		},
 	)
 
@@ -197,7 +197,7 @@ func onDelete(c client.Client) func(obj interface{}) {
 	}
 }
 
-func onUpdate(c client.Client) func(oldObj, newObj interface{}) {
+func onUpdate(c client.Client, ingressCtlCrdExists bool) func(oldObj, newObj interface{}) {
 	return func(oldObj, newObj interface{}) {
 		oldS := *oldObj.(*v1.Secret)
 		newS := *newObj.(*v1.Secret)
@@ -218,7 +218,7 @@ func onUpdate(c client.Client) func(oldObj, newObj interface{}) {
 				case name == grafanaCerts:
 					err = createCertSecret(c, nil, nil, true, grafanaCerts, false, grafanaCertificateCN, nil, nil, nil)
 				case name == serverCerts:
-					hosts, err = getHosts(c)
+					hosts, err = getHosts(c, ingressCtlCrdExists)
 					if err == nil {
 						err = createCertSecret(c, nil, nil, true, serverCerts, true, serverCertificateCN, nil, hosts, nil)
 					}

--- a/operators/multiclusterobservability/pkg/certificates/cert_controller_test.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller_test.go
@@ -107,13 +107,13 @@ func TestOnUpdate(t *testing.T) {
 	certSecret := getExpiredCertSecret()
 	oldCertLength := len(certSecret.Data["tls.crt"])
 	c := fake.NewFakeClient(certSecret)
-	onUpdate(c)(certSecret, certSecret)
+	onUpdate(c, true)(certSecret, certSecret)
 	certSecret.Name = clientCACerts
-	onUpdate(c)(certSecret, certSecret)
+	onUpdate(c, true)(certSecret, certSecret)
 	certSecret.Name = grafanaCerts
-	onUpdate(c)(certSecret, certSecret)
+	onUpdate(c, true)(certSecret, certSecret)
 	certSecret.Name = serverCerts
-	onUpdate(c)(certSecret, certSecret)
+	onUpdate(c, true)(certSecret, certSecret)
 	c.Get(context.TODO(), types.NamespacedName{Name: serverCACerts, Namespace: namespace}, certSecret)
 	if len(certSecret.Data["tls.crt"]) <= oldCertLength {
 		t.Fatal("certificate not renewed correctly")

--- a/operators/multiclusterobservability/pkg/certificates/certificates_test.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates_test.go
@@ -83,12 +83,12 @@ func TestCreateCertificates(t *testing.T) {
 
 	c := fake.NewFakeClient(route)
 
-	err := CreateObservabilityCerts(c, s, mco)
+	err := CreateObservabilityCerts(c, s, mco, true)
 	if err != nil {
 		t.Fatalf("CreateObservabilityCerts: (%v)", err)
 	}
 
-	err = CreateObservabilityCerts(c, s, mco)
+	err = CreateObservabilityCerts(c, s, mco, true)
 	if err != nil {
 		t.Fatalf("Rerun CreateObservabilityCerts: (%v)", err)
 	}

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -232,6 +232,7 @@ const (
 )
 
 const (
+	IngressControllerCRD           = "ingresscontrollers.operator.openshift.io"
 	MCHCrdName                     = "multiclusterhubs.operator.open-cluster-management.io"
 	MCOCrdName                     = "multiclusterobservabilities.observability.open-cluster-management.io"
 	StorageVersionMigrationCrdName = "storageversionmigrations.migration.k8s.io"
@@ -519,6 +520,16 @@ func GetAlertmanagerRouterCA(client client.Client) (string, error) {
 		return "", err
 	}
 	return string(routerCASecret.Data["tls.crt"]), nil
+}
+
+// GetAlertmanagerCA is used to get the CA of Alertmanager
+func GetAlertmanagerCA(client client.Client) (string, error) {
+	amCAConfigmap := &corev1.ConfigMap{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: AlertmanagersDefaultCaBundleName, Namespace: GetDefaultNamespace()}, amCAConfigmap)
+	if err != nil {
+		return "", err
+	}
+	return string(amCAConfigmap.Data["service-ca.crt"]), nil
 }
 
 func GetDefaultNamespace() string {

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -113,25 +113,25 @@ const (
 	ThanosImgName = "thanos"
 	ThanosImgTag  = "2.3.0-SNAPSHOT-2021-07-26-18-43-26"
 
-	MemcachedImgRepo = "docker.io"
+	MemcachedImgRepo = "quay.io/songleo"
 	MemcachedImgName = "memcached"
 	MemcachedImgTag  = "1.6.3-alpine"
 
-	MemcachedExporterImgRepo = "prom"
+	MemcachedExporterImgRepo = "quay.io/prometheus"
 	MemcachedExporterImgName = "memcached-exporter"
 	MemcachedExporterKey     = "memcached_exporter"
 	MemcachedExporterImgTag  = "v0.9.0"
 
-	GrafanaImgRepo            = "grafana"
-	GrafanaImgName            = "grafana"
-	GrafanaImgTagSuffix       = "7.4.2"
+	GrafanaImgRepo            = "quay.io/openshift"
+	GrafanaImgName            = "origin-grafana"
+	GrafanaImgTagSuffix       = "4.8.0"
 	GrafanaDashboardLoaderKey = "grafana_dashboard_loader"
 
 	AlertManagerImgName           = "prometheus-alertmanager"
 	AlertManagerImgKey            = "prometheus_alertmanager"
 	ConfigmapReloaderImgRepo      = "quay.io/openshift"
 	ConfigmapReloaderImgName      = "origin-configmap-reloader"
-	ConfigmapReloaderImgTagSuffix = "4.5.0"
+	ConfigmapReloaderImgTagSuffix = "4.8.0"
 	ConfigmapReloaderKey          = "prometheus-config-reloader"
 
 	OauthProxyImgRepo      = "quay.io/open-cluster-management"

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -124,6 +124,7 @@ const (
 
 	GrafanaImgRepo            = "quay.io/openshift"
 	GrafanaImgName            = "origin-grafana"
+	GrafanaImgKey             = "grafana"
 	GrafanaImgTagSuffix       = "4.8.0"
 	GrafanaDashboardLoaderKey = "grafana_dashboard_loader"
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -48,7 +48,7 @@ func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
 
 	spec := &dep.Spec.Template.Spec
 
-	found, image := config.ReplaceImage(r.cr.Annotations, config.GrafanaImgRepo, config.GrafanaImgName)
+	found, image := config.ReplaceImage(r.cr.Annotations, config.GrafanaImgRepo, config.GrafanaImgKey)
 	if found {
 		spec.Containers[0].Image = image
 	}


### PR DESCRIPTION
This PR tries to replace the openshift Route with service's DNS for testing in KinD cluster.

Signed-off-by: morvencao <lcao@redhat.com>