### PR TITLE
introduce config-reloader for prometheus to fix CA totation on *KS.

### DIFF
--- a/operators/endpointmetrics/manifests/prometheus/prometheus-statefulset.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheus-statefulset.yaml
@@ -98,6 +98,24 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      - args:
+        - -webhook-url=http://localhost:9090/-/reload
+        - -volume-dir=/etc/prometheus/secrets/hub-alertmanager-router-ca
+        - -volume-dir=/etc/prometheus/secrets/observability-alertmanager-accessor
+        image: quay.io/openshift/origin-configmap-reloader:4.5.0
+        imagePullPolicy: IfNotPresent
+        name: config-reloader
+        resources:
+          requests:
+            cpu: 4m
+            memory: 25Mi
+        volumeMounts:
+        - name: observability-alertmanager-accessor
+          mountPath: /etc/prometheus/secrets/observability-alertmanager-accessor
+          readOnly: true
+        - name: hub-alertmanager-router-ca
+          mountPath: /etc/prometheus/secrets/hub-alertmanager-router-ca
+          readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -71,6 +71,7 @@ func Render(r *rendererutil.Renderer, c runtimeclient.Client, hubInfo *operatorc
 			spec := &sts.Spec.Template.Spec
 			spec.Containers[0].Image = Images[operatorconfig.PrometheusKey]
 			spec.Containers[1].Image = Images[operatorconfig.KubeRbacProxyKey]
+			spec.Containers[2].Image = Images[operatorconfig.ConfigmapReloaderKey]
 			spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: os.Getenv(operatorconfig.PullSecret)},
 			}

--- a/operators/multiclusterobservability/manifests/endpoint-observability/images.yaml
+++ b/operators/multiclusterobservability/manifests/endpoint-observability/images.yaml
@@ -4,6 +4,7 @@ metadata:
   name: images-list
 data:
     prometheus: "quay.io/open-cluster-management/prometheus:2.4.0-SNAPSHOT-2021-08-19-08-22-43"
+    prometheus-config-reloader: "quay.io/openshift/origin-configmap-reloader:4.5.0"
     kube_state_metrics: "quay.io/open-cluster-management/kube-state-metrics:2.4.0-SNAPSHOT-2021-08-19-08-22-43"
     node_exporter: "quay.io/open-cluster-management/node-exporter:2.4.0-SNAPSHOT-2021-08-19-08-22-43"
     kube_rbac_proxy: "quay.io/open-cluster-management/kube-rbac-proxy:2.4.0-SNAPSHOT-2021-08-19-08-22-43"

--- a/operators/pkg/config/config.go
+++ b/operators/pkg/config/config.go
@@ -31,15 +31,19 @@ const (
 
 	KubeRbacProxyImgName = "kube-rbac-proxy"
 	KubeRbacProxyKey     = "kube_rbac_proxy"
+
+	ConfigmapReloaderImgName = "origin-configmap-reloader"
+	ConfigmapReloaderKey     = "prometheus-config-reloader"
 )
 
 var (
 	ImageKeyNameMap = map[string]string{
-		PrometheusKey:       PrometheusKey,
-		KubeStateMetricsKey: KubeStateMetricsImgName,
-		NodeExporterKey:     NodeExporterImgName,
-		KubeRbacProxyKey:    KubeRbacProxyImgName,
-		MetricsCollectorKey: MetricsCollectorImgName,
+		PrometheusKey:        PrometheusKey,
+		KubeStateMetricsKey:  KubeStateMetricsImgName,
+		NodeExporterKey:      NodeExporterImgName,
+		KubeRbacProxyKey:     KubeRbacProxyImgName,
+		MetricsCollectorKey:  MetricsCollectorImgName,
+		ConfigmapReloaderKey: ConfigmapReloaderImgName,
 	}
 )
 


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/15086

follow up PR for: https://github.com/open-cluster-management/multicluster-observability-operator/pull/718
Signed-off-by: morvencao <lcao@redhat.com>