### PR TITLE
fix manifestwork update conflict.

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -138,8 +138,8 @@ func createManifestwork(c client.Client, work *workv1.ManifestWork) error {
 
 	if updated {
 		log.Info("Updating manifestwork", namespace, namespace, "name", name)
-		work.ObjectMeta.ResourceVersion = found.ObjectMeta.ResourceVersion
-		err = c.Update(context.TODO(), work)
+		found.Spec.Workload.Manifests = manifests
+		err = c.Update(context.TODO(), found)
 		if err != nil {
 			log.Error(err, "Failed to update monitoring-endpoint-monitoring-work work")
 			return err


### PR DESCRIPTION
fix manifestwork update conflict:

```
2021-08-25T06:35:18.126Z	ERROR	controller_placementrule	Failed to update monitoring-endpoint-monitoring-work work	{"error": "Operation cannot be fulfilled on manifestworks.work.open-cluster-management.io \"local-cluster-observability\": the object has been modified; please apply your changes to the latest version and try again"}
2021-08-25T06:35:18.126Z	ERROR	controller_placementrule	Failed to create manifestwork	{"error": "Operation cannot be fulfilled on manifestworks.work.open-cluster-management.io \"local-cluster-observability\": the object has been modified; please apply your changes to the latest version and try again"}
2021-08-25T06:35:18.126Z	ERROR	controller_placementrule	Failed to create managedcluster resources	{"namespace": "local-cluster", "error": "Operation cannot be fulfilled on manifestworks.work.open-cluster-management.io \"local-cluster-observability\": the object has been modified; please apply your changes to the latest version and try again"}
```


Signed-off-by: morvencao <lcao@redhat.com>