### PR TITLE
reduce the duplicated loop for creating managedcluster resources

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -264,10 +264,16 @@ func createAllRelatedRes(
 	failedCreateManagedClusterRes := false
 	for managedCluster, openshiftVersion := range managedClusterList {
 		currentClusters = commonutil.Remove(currentClusters, managedCluster)
-		// only handle the request namespace if the request resource is not from observability  namespace
-		if request.Namespace == "" || request.Namespace == config.GetDefaultNamespace() ||
+		// enter the loop for the following reconcile requests:
+		// 1. MCO CR change(request namespace is emprt string and request name is "mco-updated-request")
+		// 2. configmap/secret... resource change from observability namespace
+		// 3. managedcluster change(request namespace is emprt string and request name is managedcluster name)
+		// 4. manifestwork/observabilityaddon/managedclusteraddon/rolebinding... change from managedcluster namespace
+		if (request.Namespace == "" && request.Name == config.MCOUpdatedRequestName) ||
+			request.Namespace == config.GetDefaultNamespace() ||
+			(request.Namespace == "" && request.Name == managedCluster) ||
 			request.Namespace == managedCluster {
-			log.Info("Monitoring operator should be installed in cluster", "cluster_name", managedCluster)
+			log.Info("Monitoring operator should be installed in cluster", "cluster_name", managedCluster, "request.name", request.Name, "request.namespace", request.Namespace)
 			if openshiftVersion == "3" {
 				err = createManagedClusterRes(c, restMapper, mco,
 					managedCluster, managedCluster,
@@ -679,7 +685,13 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// secondary watch for observabilityaddon
 		Watches(&source.Kind{Type: &mcov1beta1.ObservabilityAddon{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(obsAddonPred)).
 		// secondary watch for MCO
-		Watches(&source.Kind{Type: &mcov1beta2.MultiClusterObservability{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(mcoPred)).
+		Watches(&source.Kind{Type: &mcov1beta2.MultiClusterObservability{}}, handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{
+					Name: config.MCOUpdatedRequestName,
+				}},
+			}
+		}), builder.WithPredicates(mcoPred)).
 		// secondary watch for custom allowlist configmap
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(customAllowlistPred)).
 		// secondary watch for certificate secrets
@@ -756,11 +768,11 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		mchCrdExists, _ := r.CRDMap[config.MCHCrdName]
 		if mchCrdExists {
 			// secondary watch for MCH
-			ctrBuilder = ctrBuilder.Watches(&source.Kind{Type: &mchv1.MultiClusterHub{}}, handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
+			ctrBuilder = ctrBuilder.Watches(&source.Kind{Type: &mchv1.MultiClusterHub{}}, handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
 				return []reconcile.Request{
 					{NamespacedName: types.NamespacedName{
 						Name:      config.MCHUpdatedRequestName,
-						Namespace: a.GetNamespace(),
+						Namespace: obj.GetNamespace(),
 					}},
 				}
 			}), builder.WithPredicates(mchPred))

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -55,6 +55,7 @@ const (
 	DefaultImgTagSuffix    = "latest"
 
 	MCHUpdatedRequestName               = "mch-updated-request"
+	MCOUpdatedRequestName               = "mco-updated-request"
 	ImageManifestConfigMapNamePrefix    = "mch-image-manifest-"
 	OCMManifestConfigMapTypeLabelKey    = "ocm-configmap-type"
 	OCMManifestConfigMapTypeLabelValue  = "image-manifest"


### PR DESCRIPTION
This PR tries to reduce the loop for creating managedcluster resources.
Before the changes, if we create 10 managed cluster one by one, the `createManagedClusterRes` will be executed 1 + 2 + .... 10,
After the change,  the results will be 10.

For the change of MCO CR/configmap/secret and other resources the operator is watching, the number of `createManagedClusterRes` will be the number of managedcluster.

Signed-off-by: morvencao <lcao@redhat.com>