### PR TITLE
fix required fields for mco.

### DIFF
--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -35,10 +35,10 @@ type PreConfiguredStorage struct {
 	// The key of the secret to select from. Must be a valid secret key.
 	// Refer to https://thanos.io/storage.md/#configuration for a valid content of key.
 	// +required
-	Key string `json:"key,omitempty"`
+	Key string `json:"key"`
 	// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	// +required
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 }
 
 // Condition is from metav1.Condition.

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -33,11 +33,11 @@ type MultiClusterObservabilitySpec struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// Specifies the storage to be used by Observability
 	// +required
-	StorageConfig *StorageConfig `json:"storageConfig,omitempty"`
+	StorageConfig *StorageConfig `json:"storageConfig"`
 	// The ObservabilityAddonSpec defines the global settings for all managed
 	// clusters which have observability add-on enabled.
 	// +required
-	ObservabilityAddonSpec *observabilityshared.ObservabilityAddonSpec `json:"observabilityAddonSpec,omitempty"`
+	ObservabilityAddonSpec *observabilityshared.ObservabilityAddonSpec `json:"observabilityAddonSpec"`
 }
 
 type AdvancedConfig struct {
@@ -145,7 +145,7 @@ type RetentionConfig struct {
 type StorageConfig struct {
 	// Object store config secret for metrics
 	// +required
-	MetricObjectStorage *observabilityshared.PreConfiguredStorage `json:"metricObjectStorage,omitempty"`
+	MetricObjectStorage *observabilityshared.PreConfiguredStorage `json:"metricObjectStorage"`
 	// Specify the storageClass Stateful Sets. This storage class will also
 	// be used for Object Storage if MetricObjectStorage was configured for
 	// the system to create the storage.

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -130,6 +130,9 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                    required:
+                    - key
+                    - name
                     type: object
                   statefulSetSize:
                     default: 10Gi
@@ -708,6 +711,9 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                    required:
+                    - key
+                    - name
                     type: object
                   receiveStorageSize:
                     default: 100Gi
@@ -725,6 +731,8 @@ spec:
                     default: 10Gi
                     description: The amount of storage applied to thanos store stateful sets,
                     type: string
+                required:
+                - metricObjectStorage
                 type: object
               tolerations:
                 description: Tolerations causes all components to tolerate any taints.
@@ -749,6 +757,9 @@ spec:
                       type: string
                   type: object
                 type: array
+            required:
+            - observabilityAddonSpec
+            - storageConfig
             type: object
           status:
             description: MultiClusterObservabilityStatus defines the observed state of MultiClusterObservability

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -138,6 +138,9 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                    required:
+                    - key
+                    - name
                     type: object
                   statefulSetSize:
                     default: 10Gi
@@ -846,6 +849,9 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                    required:
+                    - key
+                    - name
                     type: object
                   receiveStorageSize:
                     default: 100Gi
@@ -868,6 +874,8 @@ spec:
                     description: The amount of storage applied to thanos store stateful
                       sets,
                     type: string
+                required:
+                - metricObjectStorage
                 type: object
               tolerations:
                 description: Tolerations causes all components to tolerate any taints.
@@ -909,6 +917,9 @@ spec:
                       type: string
                   type: object
                 type: array
+            required:
+            - observabilityAddonSpec
+            - storageConfig
             type: object
           status:
             description: MultiClusterObservabilityStatus defines the observed state


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/15736

There is an issued mco CR that causes mco operator crashing, after investigation, the `storageConfig` was mistaken for `storageConfigObject`.

By design, in v1beta2 mco API, the `storageConfig` and `metricObjectStorage` are required fields, so in that case, the CR should be refused to applied in to the cluster.

However, unfortunately, the required fields are not in the generated MCO CRD, the reason is:

> The omitempty tag in Foo string `json:"foo,omitempty"` had more precedence than the kubebuilder marker +kubebuilder:validation:Required therefore making the resultant generated crd field to be optional.
The +kubebuilder:validation:Required marker does works as desired when omitempty is not used.

This PR remove the `omitempty` tag from go type definition so that the `// + required` can actually take effect.


Signed-off-by: morvencao <lcao@redhat.com>