### PR TITLE
use release 2.3 to run e2e

### DIFF
--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -11,7 +11,7 @@ OBSERVABILITY_NS="open-cluster-management-observability"
 OCM_DEFAULT_NS="open-cluster-management"
 AGENT_NS="open-cluster-management-agent"
 HUB_NS="open-cluster-management-hub"
-MANAGED_CLUSTER="local-cluster"
+export MANAGED_CLUSTER="local-cluster"
 COMPONENT_REPO="quay.io/open-cluster-management"
 
 ROOTDIR="$(cd "$(dirname "$0")/.." ; pwd -P)"
@@ -140,10 +140,10 @@ deploy_hub_spoke_core() {
     if [ -d "registration-operator" ]; then
         rm -rf registration-operator
     fi
-    git clone --depth 1 -b release-2.4 https://github.com/open-cluster-management/registration-operator.git && cd registration-operator
+    git clone --depth 1 -b release-2.3 https://github.com/open-cluster-management/registration-operator.git && cd registration-operator
     $SED_COMMAND "s~clusterName: cluster1$~clusterName: $MANAGED_CLUSTER~g" deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml
-    export HUB_KUBECONFIG=${KUBECONFIG}
     # deploy hub and spoke via OLM
+    make cluster-ip
     make deploy
 
     # wait until hub and spoke are ready


### PR DESCRIPTION
use registration-operator release-2.3 to run mco e2e.
Signed-off-by: Song Song Li <ssli@redhat.com>