### PR TITLE
Update to use ResourceVersion instead of Generation for MCO CR Update

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -347,7 +347,7 @@ func (r *MultiClusterObservabilityReconciler) SetupWithManager(mgr ctrl.Manager)
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			checkStorageChanged(e.ObjectOld.(*mcov1beta2.MultiClusterObservability).Spec.StorageConfig,
 				e.ObjectNew.(*mcov1beta2.MultiClusterObservability).Spec.StorageConfig)
-			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return !e.DeleteStateUnknown


### PR DESCRIPTION
If the user adds new annotation (e.g.: mco-grafana-image), it will not trigger reconciler. That is because the generation is not changed.

Signed-off-by: clyang82 <chuyang@redhat.com>