### PR TITLE
avoid unnecessary restart during deployment

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
@@ -227,7 +227,7 @@ func updateMetricsCollector(ctx context.Context, client client.Client, obsAddonS
 			!reflect.DeepEqual(deployment.Spec.Replicas, found.Spec.Replicas) ||
 			forceRestart {
 			deployment.ObjectMeta.ResourceVersion = found.ObjectMeta.ResourceVersion
-			if forceRestart {
+			if forceRestart && found.Status.ReadyReplicas != 0 {
 				deployment.Spec.Template.ObjectMeta.Labels[restartLabel] = time.Now().Format("2006-1-2.1504")
 			}
 			err = client.Update(ctx, deployment)

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_test.go
@@ -241,6 +241,17 @@ alertmanager-router-ca: |
 	}
 
 	// test reconcile metrics collector deployment updated if cert secret updated
+	found := &appv1.Deployment{}
+	err = c.Get(ctx, types.NamespacedName{Name: metricsCollectorName,
+		Namespace: namespace}, found)
+	if err != nil {
+		t.Fatalf("Metrics collector deployment not found: (%v)", err)
+	}
+	found.Status.ReadyReplicas = 1
+	err = c.Update(ctx, found)
+	if err != nil {
+		t.Fatalf("Failed to update metrics collector deployment: (%v)", err)
+	}
 	req = ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      mtlsCertName,

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -271,8 +272,8 @@ func createManifestWorks(c client.Client, restMapper meta.RESTMapper,
 				if env.Name == "HUB_NAMESPACE" {
 					container.Env[j].Value = clusterNamespace
 				}
-				if env.Name == operatorconfig.InstallPrometheus && installProm {
-					container.Env[j].Value = "true"
+				if env.Name == operatorconfig.InstallPrometheus {
+					container.Env[j].Value = strconv.FormatBool(installProm)
 				}
 			}
 		}

--- a/operators/multiclusterobservability/pkg/certificates/cert_controller_test.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller_test.go
@@ -41,6 +41,9 @@ func newDeployment(name string) *appv1.Deployment {
 				},
 			},
 		},
+		Status: appv1.DeploymentStatus{
+			ReadyReplicas: 1,
+		},
 	}
 }
 

--- a/operators/multiclusterobservability/pkg/servicemonitor/sm_controller_test.go
+++ b/operators/multiclusterobservability/pkg/servicemonitor/sm_controller_test.go
@@ -25,7 +25,7 @@ func TestRewriteLabels(t *testing.T) {
 			},
 		},
 	}
-	updated := rewriteLabels(sm)
+	updated := rewriteLabels(sm, "")
 	if len(updated.Spec.NamespaceSelector.MatchNames) == 0 || updated.Spec.NamespaceSelector.MatchNames[0] != config.GetDefaultNamespace() {
 		t.Errorf("Wrong NamespaceSelector: %v", updated.Spec.NamespaceSelector)
 	}


### PR DESCRIPTION
1. fixed restart problem: https://github.com/open-cluster-management/backlog/issues/15493
2. fixed servicemonitor create/update issue
3. fixed problem in createmanifestwork() that install_prom's default value is reset by *KS cluster will lead to problem in Openshift cluster
Signed-off-by: Marco <llan@redhat.com>