### PR TITLE
[wip]fix metrics check issue

### DIFF
--- a/tests/pkg/tests/observability_grafana_test.go
+++ b/tests/pkg/tests/observability_grafana_test.go
@@ -4,8 +4,6 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -27,18 +25,8 @@ var _ = Describe("Observability:", func() {
 
 	It("[P1][Sev1][Observability][Stable] Should have metric data in grafana console (grafana/g0)", func() {
 		Eventually(func() error {
-			clusters, err := utils.ListManagedClusters(testOptions)
-			if err != nil {
-				return err
-			}
-			for _, cluster := range clusters {
-				query := fmt.Sprintf("node_memory_MemAvailable_bytes{cluster=\"%s\"}", cluster)
-				err, _ = utils.ContainManagedClusterMetric(testOptions, query, []string{`"__name__":"node_memory_MemAvailable_bytes"`})
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			err, _ = utils.ContainManagedClusterMetric(testOptions, "node_memory_MemAvailable_bytes", []string{`"__name__":"node_memory_MemAvailable_bytes"`})
+			return err
 		}, EventuallyTimeoutMinute*6, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 

--- a/tests/pkg/tests/observability_metrics_test.go
+++ b/tests/pkg/tests/observability_metrics_test.go
@@ -5,7 +5,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -51,44 +50,24 @@ var _ = Describe("Observability:", func() {
 
 		By("Waiting for new added metrics on grafana console")
 		Eventually(func() error {
-			for _, cluster := range clusters {
-				query := fmt.Sprintf("node_memory_Active_bytes{cluster=\"%s\"} offset 1m", cluster)
-				err, _ := utils.ContainManagedClusterMetric(testOptions, query, []string{`"__name__":"node_memory_Active_bytes"`})
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			err, _ := utils.ContainManagedClusterMetric(testOptions, "node_memory_Active_bytes offset 1m", []string{`"__name__":"node_memory_Active_bytes"`})
+			return err
 		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	It("[P2][Sev2][Observability][Integration] Should have no metrics which have been marked for deletion in names section (metrics/g0)", func() {
 		By("Waiting for deleted metrics disappear on grafana console")
 		Eventually(func() error {
-			for _, cluster := range clusters {
-				query := fmt.Sprintf("timestamp(instance:node_num_cpu:sum{cluster=\"%s\"}) - timestamp(instance:node_num_cpu:sum{cluster=\"%s\"} offset 1m) > 59",
-					cluster, cluster)
-				metricslistError, _ = utils.ContainManagedClusterMetric(testOptions, query, []string{})
-				if metricslistError == nil {
-					return nil
-				}
-			}
-			return metricslistError
+			err, _ := utils.ContainManagedClusterMetric(testOptions, "timestamp(cluster_version_payload) - timestamp(cluster_version_payload offset 1m) > 59", []string{})
+			return err
 		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(MatchError("Failed to find metric name from response"))
 	})
 
 	It("[P2][Sev2][Observability][Integration] Should have no metrics which have been marked for deletion in matches section (metrics/g0)", func() {
 		By("Waiting for deleted metrics disappear on grafana console")
 		Eventually(func() error {
-			for _, cluster := range clusters {
-				query := fmt.Sprintf("timestamp(go_goroutines{cluster=\"%s\"}) - timestamp(go_goroutines{cluster=\"%s\"} offset 1m) > 59",
-					cluster, cluster)
-				metricslistError, _ = utils.ContainManagedClusterMetric(testOptions, query, []string{})
-				if metricslistError == nil {
-					return nil
-				}
-			}
-			return metricslistError
+			err, _ := utils.ContainManagedClusterMetric(testOptions, "timestamp(go_goroutines) - timestamp(go_goroutines offset 1m) > 59", []string{})
+			return err
 		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(MatchError("Failed to find metric name from response"))
 	})
 
@@ -101,15 +80,8 @@ var _ = Describe("Observability:", func() {
 
 		By("Waiting for new added metrics disappear on grafana console")
 		Eventually(func() error {
-			for _, cluster := range clusters {
-				query := fmt.Sprintf("timestamp(node_memory_Active_bytes{cluster=\"%s\"}) - timestamp(node_memory_Active_bytes{cluster=\"%s\"} offset 1m) > 59",
-					cluster, cluster)
-				metricslistError, _ = utils.ContainManagedClusterMetric(testOptions, query, []string{})
-				if metricslistError == nil {
-					return nil
-				}
-			}
-			return metricslistError
+			err, _ := utils.ContainManagedClusterMetric(testOptions, "timestamp(node_memory_Active_bytes) - timestamp(node_memory_Active_bytes offset 1m) > 59", []string{})
+			return err
 		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(MatchError("Failed to find metric name from response"))
 	})
 


### PR DESCRIPTION
In canary test env, we just check the obs addon status in the first managedcluster, for the other managedclusters, we can not to check the addon status. if the addon status is not ready, we can not check the metrics from these managedclusters. 

 fix https://github.com/open-cluster-management/backlog/issues/16007
Signed-off-by: Song Song Li <ssli@redhat.com>