### PR TITLE
Revert "Depend on MCH loosely"

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -740,7 +740,10 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		mchPred := predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
 				// this is for operator restart, the mch CREATE event will be caught and the mch should be ready
-				if e.Object.GetNamespace() == config.GetMCONamespace() {
+				if e.Object.GetNamespace() == config.GetMCONamespace() &&
+					e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion != "" &&
+					e.Object.(*mchv1.MultiClusterHub).Status.DesiredVersion == e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion {
+					// only read the image manifests configmap and enqueue the request when the MCH is installed/upgraded successfully
 					ok, err := config.ReadImageManifestConfigMap(c, e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion)
 					if err != nil {
 						return false
@@ -751,7 +754,10 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				if e.ObjectNew.GetNamespace() == config.GetMCONamespace() &&
-					e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() {
+					e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
+					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion != "" &&
+					e.ObjectNew.(*mchv1.MultiClusterHub).Status.DesiredVersion == e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion {
+					/// only read the image manifests configmap and enqueue the request when the MCH is installed/upgraded successfully
 					ok, err := config.ReadImageManifestConfigMap(c, e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion)
 					if err != nil {
 						return false


### PR DESCRIPTION
Reverts open-cluster-management/multicluster-observability-operator#729

We need depend on MCH ready and then update images to fix this known issue:

> 1.3.3.8. Observability stateful set uses wrong images in disconnected environment. In rare cases with disconnected environments, some pods of the observability StatefulSet are stuck in the following status, ErrPullImage because the pods cannot pull the images. The images defined in those pods are different from the ones defined in the related StatefulSets. To fix this problem, you need to delete the pods that use the wrong images. The pods restart automatically and should use the correct images. 