### PR TITLE
fix no data in dashboard for rate interval.

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
@@ -54,10 +54,6 @@ data:
           record: cluster:cpu_requested:ratio
           labels:
             usage: grafana-dashboard
-        - expr: 1 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) by (cluster)
-          record: cluster:cpu_utilized:ratio:5m
-          labels:
-            usage: grafana-dashboard
         - expr: sum(cluster:kube_pod_container_resource_requests:memory:sum) by (cluster) / sum(kube_node_status_allocatable{resource="memory"}) by (cluster)
           record: cluster:memory_requested:ratio
           labels:

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview.yaml
@@ -711,7 +711,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "topk(50, cluster:cpu_requested:ratio - ignoring(usage) cluster:cpu_utilized:ratio:5m)\n* on(cluster) group_left(cpu_requested) count_values without() (\"cpu_requested\", cluster:cpu_requested:ratio)\n* on(cluster) group_left(cpu_utilized) count_values without() (\"cpu_utilized\", cluster:cpu_utilized:ratio:5m)",
+              "expr": "topk(50, cluster:cpu_requested:ratio - ignoring(usage) (1 - avg(rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval])) by (cluster)))\n* on(cluster) group_left(cpu_requested) count_values without() (\"cpu_requested\", cluster:cpu_requested:ratio)\n* on(cluster) group_left(cpu_utilized) count_values without() (\"cpu_utilized\", (1 - avg(rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval])) by (cluster)))",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -1144,7 +1144,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "topk(50, cluster:cpu_utilized:ratio:5m)\n* on(cluster) group_left(machine_cpu_cores_sum) count_values without() (\"machine_cpu_cores_sum\", cluster:cpu_cores:sum)\n* on(cluster) group_left(node_allocatable_cpu_cores_sum) count_values without() (\"node_allocatable_cpu_cores_sum\", cluster:cpu_allocatable:sum)\n* on(cluster) group_left(cpu_requested) count_values without() (\"cpu_requested\", cluster:cpu_requested:ratio)",
+              "expr": "topk(50, (1 - avg(rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval])) by (cluster)))\n* on(cluster) group_left(machine_cpu_cores_sum) count_values without() (\"machine_cpu_cores_sum\", cluster:cpu_cores:sum)\n* on(cluster) group_left(node_allocatable_cpu_cores_sum) count_values without() (\"node_allocatable_cpu_cores_sum\", cluster:cpu_allocatable:sum)\n* on(cluster) group_left(cpu_requested) count_values without() (\"cpu_requested\", cluster:cpu_requested:ratio)",
               "instant": true,
               "interval": "",
               "legendFormat": "",


### PR DESCRIPTION
This is a follow up PR for: https://github.com/open-cluster-management/multicluster-observability-operator/pull/769
I found no data in CPU Overestimation Panel, because we have updated the prometheus scrape interval in managedcluster from 30s to 5m(300s) in https://github.com/open-cluster-management/multicluster-observability-operator/pull/763.

And the `rate` query need to be at least 4* `$scrape_interval` according to the https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/

What we need to do is using the `$__rate_interval` to replace the old `$__interval`


Signed-off-by: morvencao <lcao@redhat.com>