### PR TITLE
Use default snapshot for all our images

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -325,8 +325,7 @@ func newAPISpec(mco *mcov1beta2.MultiClusterObservability) obsv1alpha1.APISpec {
 	}
 	//set the default observatorium components' image
 	apiSpec.Image = mcoconfig.DefaultImgRepository + "/" + mcoconfig.ObservatoriumAPIImgName +
-		":" + mcoconfig.ObservatoriumAPIImgTag
-	apiSpec.Version = mcoconfig.ObservatoriumAPIImgTag
+		":" + mcoconfig.DefaultImgTagSuffix
 	replace, image := mcoconfig.ReplaceImage(mco.Annotations, apiSpec.Image, mcoconfig.ObservatoriumAPIImgName)
 	if replace {
 		apiSpec.Image = image
@@ -517,8 +516,8 @@ func newMemCacheSpec(component string, mco *mcov1beta2.MultiClusterObservability
 
 func newThanosSpec(mco *mcov1beta2.MultiClusterObservability, scSelected string) obsv1alpha1.ThanosSpec {
 	thanosSpec := obsv1alpha1.ThanosSpec{}
-	thanosSpec.Image = mcoconfig.DefaultImgRepository + "/" + mcoconfig.ThanosImgName + ":" + mcoconfig.ThanosImgTag
-	thanosSpec.Version = mcoconfig.ThanosImgTag
+	thanosSpec.Image = mcoconfig.DefaultImgRepository + "/" + mcoconfig.ThanosImgName +
+		":" + mcoconfig.DefaultImgTagSuffix
 
 	thanosSpec.Compact = newCompactSpec(mco, scSelected)
 	thanosSpec.Receivers = newReceiversSpec(mco, scSelected)

--- a/operators/multiclusterobservability/controllers/placementrule/endpoint_metrics_operator.go
+++ b/operators/multiclusterobservability/controllers/placementrule/endpoint_metrics_operator.go
@@ -138,7 +138,7 @@ func updateRes(r *resource.Resource,
 func updateEndpointOperator(mco *mcov1beta2.MultiClusterObservability,
 	container corev1.Container) corev1.Container {
 	container.Image = getImage(mco, mcoconfig.EndpointControllerImgName,
-		mcoconfig.EndpointControllerImgTagSuffix, mcoconfig.EndpointControllerKey)
+		mcoconfig.DefaultImgTagSuffix, mcoconfig.EndpointControllerKey)
 	container.ImagePullPolicy = mcoconfig.GetImagePullPolicy(mco.Spec)
 	for i, env := range container.Env {
 		if env.Name == operatorconfig.PullSecret {

--- a/operators/multiclusterobservability/manifests/base/alertmanager/alertmanager-statefulset.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alertmanager-statefulset.yaml
@@ -80,7 +80,7 @@ spec:
         - -webhook-url=http://localhost:9093/-/reload
         - -volume-dir=/etc/alertmanager/config
         - -volume-dir=/etc/tls/private
-        image: quay.io/openshift/origin-configmap-reloader:4.5.0
+        image: quay.io/openshift/origin-configmap-reloader:4.8.0
         imagePullPolicy: IfNotPresent
         name: config-reloader
         resources:

--- a/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
       - args:
         - -config=/etc/grafana/grafana.ini
-        image:  quay.io/openshift/origin-grafana:4.8.0
+        image: quay.io/open-cluster-management/grafana:2.4.0-SNAPSHOT-2021-09-23-07-02-14
         imagePullPolicy: Always
         name: grafana
         ports:

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -51,10 +51,6 @@ const (
 	AnnotationMCOWithoutResourcesRequests = "mco-thanos-without-resources-requests"
 	AnnotationCertDuration                = "mco-cert-duration"
 
-	DefaultImgRepository   = "quay.io/open-cluster-management"
-	DefaultDSImgRepository = "quay.io:443/acm-d"
-	DefaultImgTagSuffix    = "latest"
-
 	MCHUpdatedRequestName               = "mch-updated-request"
 	MCOUpdatedRequestName               = "mco-updated-request"
 	ImageManifestConfigMapNamePrefix    = "mch-image-manifest-"
@@ -105,17 +101,17 @@ const (
 )
 
 const (
-	ObservatoriumImgRepo           = "quay.io/observatorium"
+	DefaultImgRepository = "quay.io/open-cluster-management"
+	DefaultImgTagSuffix  = "2.4.0-SNAPSHOT-2021-09-23-07-02-14"
+
 	ObservatoriumAPIImgName        = "observatorium"
-	ObservatoriumAPIImgTag         = "2.3.0-SNAPSHOT-2021-07-26-18-43-26"
-	ObservatoriumOperatorImgName   = "observatorium_operator"
+	ObservatoriumOperatorImgName   = "observatorium-operator"
+	ObservatoriumOperatorImgKey    = "observatorium_operator"
 	ThanosReceiveControllerImgName = "thanos-receive-controller"
 	//ThanosReceiveControllerKey is used to get from mch-image-manifest.xxx configmap
 	ThanosReceiveControllerKey    = "thanos_receive_controller"
 	ThanosReceiveControllerImgTag = "master-2021-04-28-ee165b6"
-
-	ThanosImgName = "thanos"
-	ThanosImgTag  = "2.3.0-SNAPSHOT-2021-07-26-18-43-26"
+	ThanosImgName                 = "thanos"
 
 	MemcachedImgRepo = "quay.io/ocm-observability"
 	MemcachedImgName = "memcached"
@@ -126,11 +122,9 @@ const (
 	MemcachedExporterKey     = "memcached_exporter"
 	MemcachedExporterImgTag  = "v0.9.0"
 
-	GrafanaImgRepo            = "quay.io/openshift"
-	GrafanaImgName            = "origin-grafana"
-	GrafanaImgKey             = "grafana"
-	GrafanaImgTagSuffix       = "4.8.0"
-	GrafanaDashboardLoaderKey = "grafana_dashboard_loader"
+	GrafanaImgKey              = "grafana"
+	GrafanaDashboardLoaderName = "grafana-dashboard-loader"
+	GrafanaDashboardLoaderKey  = "grafana_dashboard_loader"
 
 	AlertManagerImgName           = "prometheus-alertmanager"
 	AlertManagerImgKey            = "prometheus_alertmanager"
@@ -141,14 +135,14 @@ const (
 
 	OauthProxyImgRepo      = "quay.io/open-cluster-management"
 	OauthProxyImgName      = "origin-oauth-proxy"
-	OauthProxyImgTagSuffix = "2.0.11-SNAPSHOT-2021-04-29-18-29-17"
+	OauthProxyImgTagSuffix = "2.0.12-SNAPSHOT-2021-06-11-19-40-10"
 	OauthProxyKey          = "oauth_proxy"
 
-	EndpointControllerImgTagSuffix = "2.3.0-SNAPSHOT-2021-07-26-18-43-26"
-	EndpointControllerImgName      = "endpoint-monitoring-operator"
-	EndpointControllerKey          = "endpoint_monitoring_operator"
+	EndpointControllerImgName = "endpoint-monitoring-operator"
+	EndpointControllerKey     = "endpoint_monitoring_operator"
 
-	RBACQueryProxyKey = "rbac_query_proxy"
+	RBACQueryProxyImgName = "rbac-query-proxy"
+	RBACQueryProxyKey     = "rbac_query_proxy"
 
 	RBACQueryProxyCPURequets    = "20m"
 	RBACQueryProxyMemoryRequets = "100Mi"

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -104,6 +104,7 @@ const (
 	DefaultImgRepository = "quay.io/open-cluster-management"
 	DefaultImgTagSuffix  = "2.4.0-SNAPSHOT-2021-09-23-07-02-14"
 
+	ObservatoriumImgRepo           = "quay.io/observatorium"
 	ObservatoriumAPIImgName        = "observatorium"
 	ObservatoriumOperatorImgName   = "observatorium-operator"
 	ObservatoriumOperatorImgKey    = "observatorium_operator"

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -26,9 +26,10 @@ import (
 )
 
 var (
-	apiServerURL = "http://example.com"
-	clusterID    = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-	version      = "2.1.1"
+	apiServerURL           = "http://example.com"
+	clusterID              = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+	version                = "2.1.1"
+	DefaultDSImgRepository = "quay.io:443/acm-d"
 )
 
 func TestGetClusterNameLabelKey(t *testing.T) {

--- a/operators/multiclusterobservability/pkg/rendering/renderer.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer.go
@@ -128,8 +128,11 @@ func (r *MCORenderer) Render() ([]*unstructured.Unstructured, error) {
 			switch resources[idx].GetName() {
 
 			case "observatorium-operator":
+				spec.Containers[0].Image = mcoconfig.DefaultImgRepository + "/" +
+					mcoconfig.ObservatoriumOperatorImgName + ":" + mcoconfig.DefaultImgTagSuffix
+
 				found, image := mcoconfig.ReplaceImage(r.cr.Annotations, spec.Containers[0].Image,
-					mcoconfig.ObservatoriumOperatorImgName)
+					mcoconfig.ObservatoriumOperatorImgKey)
 				if found {
 					spec.Containers[0].Image = image
 				}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -76,6 +76,8 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource,
 		{Name: mcoconfig.GetImagePullSecret(r.cr.Spec)},
 	}
 
+	spec.Containers[0].Image = mcoconfig.DefaultImgRepository + "/" + mcoconfig.AlertManagerImgName +
+		":" + mcoconfig.DefaultImgTagSuffix
 	//replace the alertmanager and config-reloader images
 	found, image := mcoconfig.ReplaceImage(
 		r.cr.Annotations,

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -48,11 +48,16 @@ func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
 
 	spec := &dep.Spec.Template.Spec
 
-	found, image := config.ReplaceImage(r.cr.Annotations, config.GrafanaImgRepo, config.GrafanaImgKey)
+	spec.Containers[0].Image = config.DefaultImgRepository + "/" + config.GrafanaImgKey +
+		":" + config.DefaultImgTagSuffix
+	found, image := config.ReplaceImage(r.cr.Annotations, spec.Containers[0].Image, config.GrafanaImgKey)
 	if found {
 		spec.Containers[0].Image = image
 	}
 	spec.Containers[0].Resources = config.GetResources(config.Grafana, r.cr.Spec.AdvancedConfig)
+
+	spec.Containers[1].Image = config.DefaultImgRepository + "/" + config.GrafanaDashboardLoaderName +
+		":" + config.DefaultImgTagSuffix
 	found, image = config.ReplaceImage(r.cr.Annotations, spec.Containers[1].Image,
 		config.GrafanaDashboardLoaderKey)
 	if found {

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -76,6 +76,8 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 		{Name: mcoconfig.GetImagePullSecret(r.cr.Spec)},
 	}
 
+	spec.Containers[0].Image = config.DefaultImgRepository + "/" + config.RBACQueryProxyImgName +
+		":" + config.DefaultImgTagSuffix
 	//replace the proxy image
 	found, image := mcoconfig.ReplaceImage(
 		r.cr.Annotations,

--- a/tests/grafana-dev-test.sh
+++ b/tests/grafana-dev-test.sh
@@ -4,13 +4,11 @@ base_dir="$(cd "$(dirname "$0")/.." ; pwd -P)"
 cd "$base_dir"
 obs_namespace=open-cluster-management-observability
 
-git clone --depth 1 https://github.com/open-cluster-management/multicluster-observability-operator.git grafana-dev-test
-
 # create a dashboard for test export grafana dashboard
 kubectl apply -n "$obs_namespace" -f "$base_dir"/examples/dashboards/sample_custom_dashboard/custom-sample-dashboard.yaml
 
 # test deploy grafana-dev
-cd grafana-dev-test/tools
+cd $base_dir/tools
 ./setup-grafana-dev.sh --deploy
 if [ $? -ne 0 ]; then
     echo "Failed run setup-grafana-dev.sh --deploy"
@@ -63,5 +61,4 @@ if [ $? -ne 0 ]; then
 fi
 
 # clean test env
-rm -rf "$base_dir"/grafana-dev-test
 kubectl delete -n "$obs_namespace" -f "$base_dir"/examples/dashboards/sample_custom_dashboard/custom-sample-dashboard.yaml

--- a/tests/grafana-dev-test.sh
+++ b/tests/grafana-dev-test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# avoid client-side throttling due to HOME=/
+export HOME=/tmp
+
 base_dir="$(cd "$(dirname "$0")/.." ; pwd -P)"
 cd "$base_dir"
 obs_namespace=open-cluster-management-observability

--- a/tests/pkg/tests/observability_grafana_dev_test.go
+++ b/tests/pkg/tests/observability_grafana_dev_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		time.Sleep(10 * time.Hour)
+		time.Sleep(1 * time.Hour)
 		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 	})
 

--- a/tests/pkg/tests/observability_grafana_dev_test.go
+++ b/tests/pkg/tests/observability_grafana_dev_test.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"bytes"
 	"os/exec"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,6 +29,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
+		time.Sleep(10 * time.Hour)
 		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 	})
 

--- a/tests/pkg/tests/observability_grafana_dev_test.go
+++ b/tests/pkg/tests/observability_grafana_dev_test.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"bytes"
 	"os/exec"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,7 +28,6 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		time.Sleep(1 * time.Hour)
 		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 	})
 

--- a/tests/pkg/tests/observability_grafana_dev_test.go
+++ b/tests/pkg/tests/observability_grafana_dev_test.go
@@ -23,9 +23,7 @@ var _ = Describe("Observability:", func() {
 		var out bytes.Buffer
 		cmd.Stdout = &out
 		err := cmd.Run()
-		if err != nil {
-			klog.V(1).Infof("Failed to run grafana-dev-test.sh: %v", out.String())
-		}
+		klog.V(1).Infof("the output of grafana-dev-test.sh: %v", out.String())
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/tests/pkg/tests/observability_grafana_dev_test.go
+++ b/tests/pkg/tests/observability_grafana_dev_test.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"bytes"
 	"os/exec"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,6 +29,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
+		time.Sleep(1 * time.Hour)
 		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 	})
 

--- a/tools/generate-dashboard-configmap-yaml.sh
+++ b/tools/generate-dashboard-configmap-yaml.sh
@@ -88,18 +88,13 @@ start() {
       echo "Failed to search dashboards, please check your grafana-dev instance"
       exit 1
   fi
-  echo $dashboards
 
-  dashboard=`echo $dashboards | python -c "import sys, json;[sys.stdout.write(json.dumps(dash)) for dash in json.load(sys.stdin) if dash['title'] == '$org_dashboard_name']"`
-
-  echo $dashboard
+  dashboard=`echo $dashboards | $PYTHON_CMD -c "import sys, json;[sys.stdout.write(json.dumps(dash)) for dash in json.load(sys.stdin) if dash['title'] == '$org_dashboard_name']"`
 
   dashboardUID=`echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['uid'])" 2>/dev/null`
   dashboardFolderId=`echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['folderId'])" 2>/dev/null`
   dashboardFolderTitle=`echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['folderTitle'])" 2>/dev/null`
   
- echo $dashboardUID
-
   dashboardJson=`$curlCMD -s -X GET -H "Content-Type: application/json" -H "X-Forwarded-User:$XForwardedUser" 127.0.0.1:3001/api/dashboards/uid/$dashboardUID | $PYTHON_CMD -c "import sys, json; print(json.dumps(json.load(sys.stdin)['dashboard']))" 2>/dev/null`
   if [ $? -ne 0 ]; then
       echo "Failed to fetch dashboard json data, please check your dashboard name <$org_dashboard_name>"

--- a/tools/generate-dashboard-configmap-yaml.sh
+++ b/tools/generate-dashboard-configmap-yaml.sh
@@ -85,16 +85,21 @@ start() {
   XForwardedUser="WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000"
   dashboards=`$curlCMD -s -X GET -H "Content-Type: application/json" -H "X-Forwarded-User: $XForwardedUser" 127.0.0.1:3001/api/search`
   if [ $? -ne 0 ]; then
-      echo "Failed to fetch dashboard UID, please check your dashboard name"
+      echo "Failed to search dashboards, please check your grafana-dev instance"
       exit 1
   fi
+  echo $dashboards
 
   dashboard=`echo $dashboards | python -c "import sys, json;[sys.stdout.write(json.dumps(dash)) for dash in json.load(sys.stdin) if dash['title'] == '$org_dashboard_name']"`
+
+  echo $dashboard
 
   dashboardUID=`echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['uid'])" 2>/dev/null`
   dashboardFolderId=`echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['folderId'])" 2>/dev/null`
   dashboardFolderTitle=`echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['folderTitle'])" 2>/dev/null`
   
+ echo $dashboardUID
+
   dashboardJson=`$curlCMD -s -X GET -H "Content-Type: application/json" -H "X-Forwarded-User:$XForwardedUser" 127.0.0.1:3001/api/dashboards/uid/$dashboardUID | $PYTHON_CMD -c "import sys, json; print(json.dumps(json.load(sys.stdin)['dashboard']))" 2>/dev/null`
   if [ $? -ne 0 ]; then
       echo "Failed to fetch dashboard json data, please check your dashboard name <$org_dashboard_name>"


### PR DESCRIPTION
Update to use default snapshot for all our owned images. We pass the `mco-imageTagSuffix` in e2e test. but the grafana is still using the `quay.io/openshift/origin-grafana:4.8.0`. This PR is to define the default `DefaultImgTagSuffix` only in config.go. so we can use this default value in case cannot replace the correct images.

Signed-off-by: clyang82 <chuyang@redhat.com>