### PR TITLE
remove unused merge transform from cluster overview dashboard.

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview.yaml
@@ -261,12 +261,6 @@ data:
           "title": "Top 50 Max Latency API Server",
           "transformations": [
             {
-              "id": "merge",
-              "options": {
-                "reducers": []
-              }
-            },
-            {
               "id": "filterFieldsByName",
               "options": {
                 "include": {
@@ -480,10 +474,6 @@ data:
                   ]
                 }
               }
-            },
-            {
-              "id": "merge",
-              "options": {}
             },
             {
               "id": "organize",
@@ -1725,10 +1715,6 @@ data:
                   ]
                 }
               }
-            },
-            {
-              "id": "merge",
-              "options": {}
             },
             {
               "id": "sortBy",


### PR DESCRIPTION
As you can see from panel settings, the `merge` transforms actually have no effect for single frame in panels.

![image](https://user-images.githubusercontent.com/5468682/134624531-fb28d945-5a27-4ae3-8731-9049c562238e.png)


Signed-off-by: morvencao <lcao@redhat.com>