### PR TITLE
Updated SLO dashboard label and remove SLO name from recording rule

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
@@ -46,7 +46,6 @@ data:
         - expr: sli:apiserver_request_duration_seconds:trend:1m >= bool 0.9900
           record: sli:apiserver_request_duration_seconds:bin:trend:1m
           labels:
-            slo: "API Server Request Duration"
             target: 0.9900
       - name: grafana-dashboard
         rules:

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-k8s-service-level-overview-api-server-cluster.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-k8s-service-level-overview-api-server-cluster.yaml
@@ -20,7 +20,7 @@ data:
       "gnetId": null,
       "graphTooltip": 0,
       "id": 13,
-      "iteration": 1632264932705,
+      "iteration": 1632761729352,
       "links": [
         {
           "icon": "dashboard",
@@ -903,7 +903,7 @@ data:
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Value"
+                  "options": "SLI"
                 },
                 "properties": [
                   {
@@ -973,6 +973,7 @@ data:
                 "excludeByName": {},
                 "indexByName": {},
                 "renameByName": {
+                  "Value": "SLI",
                   "cluster": "Cluster",
                   "clusterID": "ClusterID"
                 }


### PR DESCRIPTION
This PR will remove the `slo` label from the recording rule. The SLO name is already displayed within the dashboard; therefore, in this contexts, it's not needed.

Related issue: https://github.com/open-cluster-management/backlog/issues/16542

Signed-off-by: dislbenn <lavontae.bennett@gmail.com>