### PR TITLE
fixed order for map

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"time"
 
@@ -47,7 +48,7 @@ var (
 type MetricsAllowlist struct {
 	NameList  []string          `yaml:"names"`
 	MatchList []string          `yaml:"matches"`
-	ReNameMap map[string]string `yaml:"renames"`
+	RenameMap map[string]string `yaml:"renames"`
 	RuleList  []Rule            `yaml:"rules"`
 }
 
@@ -139,8 +140,14 @@ func createDeployment(clusterID string, clusterType string,
 	for _, match := range allowlist.MatchList {
 		commands = append(commands, fmt.Sprintf("--match={%s}", match))
 	}
-	for k, v := range allowlist.ReNameMap {
-		commands = append(commands, fmt.Sprintf("--rename=\"%s=%s\"", k, v))
+
+	renamekeys := make([]string, 0, len(allowlist.RenameMap))
+	for k := range allowlist.RenameMap {
+		renamekeys = append(renamekeys, k)
+	}
+	sort.Strings(renamekeys)
+	for _, k := range renamekeys {
+		commands = append(commands, fmt.Sprintf("--rename=\"%s=%s\"", k, allowlist.RenameMap[k]))
 	}
 	for _, rule := range allowlist.RuleList {
 		commands = append(commands, fmt.Sprintf("--recordingrule={\"name\":\"%s\",\"query\":\"%s\"}", rule.Record, rule.Expr))

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -57,7 +57,7 @@ var (
 type MetricsAllowlist struct {
 	NameList  []string          `yaml:"names"`
 	MatchList []string          `yaml:"matches"`
-	ReNameMap map[string]string `yaml:"renames"`
+	RenameMap map[string]string `yaml:"renames"`
 	RuleList  []Rule            `yaml:"rules"`
 }
 
@@ -498,8 +498,8 @@ func generateMetricsListCM(client client.Client) (*corev1.ConfigMap, error) {
 		allowlist.NameList = mergeMetrics(allowlist.NameList, customAllowlist.NameList)
 		allowlist.MatchList = mergeMetrics(allowlist.MatchList, customAllowlist.MatchList)
 		allowlist.RuleList = append(allowlist.RuleList, customAllowlist.RuleList...)
-		for k, v := range customAllowlist.ReNameMap {
-			allowlist.ReNameMap[k] = v
+		for k, v := range customAllowlist.RenameMap {
+			allowlist.RenameMap[k] = v
 		}
 	} else {
 		log.Info("There is no custom metrics allowlist configmap in the cluster")


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/17727

the root cause for the canary failure is: there are 2 metrics-collector instances running in obs-addon namespace. one is running and the other is terminating. for the terminating pod, the status.phase is running. why there are 2 metrics-collector instances exist? The reason is the endpoint-monitoring-operator does the reconciler to generate the metrics-collector deployment manifests. but the manifest can be different each time, because the map order is random. for example:
the first time for rename order:
```
        - --rename="mixin_pod_workload=namespace_workload_pod:kube_pod_owner:relabel"
        - --rename="namespace:kube_pod_container_resource_requests_cpu_cores:sum=namespace_cpu:kube_pod_container_resource_requests:sum"
        - --rename="node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate=node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate"
        - --rename="etcd_mvcc_db_total_size_in_bytes=etcd_debugging_mvcc_db_total_size_in_bytes”

```

the second one is
```
        - --rename="node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate=node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate"
        - --rename="etcd_mvcc_db_total_size_in_bytes=etcd_debugging_mvcc_db_total_size_in_bytes"
        - --rename="mixin_pod_workload=namespace_workload_pod:kube_pod_owner:relabel"
        - --rename="namespace:kube_pod_container_resource_requests_cpu_cores:sum=namespace_cpu:kube_pod_container_resource_requests:sum"

```
That leads to generate the new metrics-collector pod.

Signed-off-by: clyang82 <chuyang@redhat.com>