### PR TITLE
add e2e case for alert forward from managed clusters.

### DIFF
--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -124,11 +124,11 @@ get_ginkgo_focus() {
             continue
         fi
         if [[ $file =~ ^operators/multiclusterobservability ]]; then
-            GINKGO_FOCUS+=" --focus addon/g0 --focus config/g0 --focus alert/g0 --focus certrenew/g0 --focus grafana/g0 --focus grafana_dev/g0 --focus dashboard/g0 --focus manifestwork/g0 --focus metrics/g0 --focus observatorium_preserve/g0 --focus reconcile/g0 --focus retention/g0"
+            GINKGO_FOCUS+=" --focus addon/g0 --focus config/g0 --focus alert/g0 --focus alertforward/g0 --focus certrenew/g0 --focus grafana/g0 --focus grafana_dev/g0 --focus dashboard/g0 --focus manifestwork/g0 --focus metrics/g0 --focus observatorium_preserve/g0 --focus reconcile/g0 --focus retention/g0"
             continue
         fi
         if [[ $file =~ ^operators/pkg ]]; then
-            GINKGO_FOCUS+=" --focus addon/g0 --focus config/g0 --focus alert/g0 --focus certrenew/g0 --focus grafana/g0 --focus grafana_dev/g0 --focus dashboard/g0 --focus manifestwork/g0 --focus metrics/g0 --focus observatorium_preserve/g0 --focus reconcile/g0 --focus retention/g0 --focus endpoint_preserve/g0"
+            GINKGO_FOCUS+=" --focus addon/g0 --focus config/g0 --focus alert/g0 --focus alertforward/g0  --focus certrenew/g0 --focus grafana/g0 --focus grafana_dev/g0 --focus dashboard/g0 --focus manifestwork/g0 --focus metrics/g0 --focus observatorium_preserve/g0 --focus reconcile/g0 --focus retention/g0 --focus endpoint_preserve/g0"
             continue
         fi
         if [[ $file =~ ^pkg ]]; then
@@ -137,7 +137,7 @@ get_ginkgo_focus() {
             break
         fi
         if [[ $file =~ ^examples/alerts ]]; then
-            GINKGO_FOCUS+=" --focus alert/g0"
+            GINKGO_FOCUS+=" --focus alert/g0 --focus alertforward/g0"
             continue
         fi
         if [[ $file =~ ^examples/dashboards ]]; then

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -141,7 +141,7 @@ deploy_hub_spoke_core() {
     if [ -d "registration-operator" ]; then
         rm -rf registration-operator
     fi
-    git clone --depth 1 -b release-2.3 https://github.com/open-cluster-management/registration-operator.git && cd registration-operator
+    git clone --depth 1 -b release-2.4 https://github.com/open-cluster-management/registration-operator.git && cd registration-operator
     $SED_COMMAND "s~clusterName: cluster1$~clusterName: $MANAGED_CLUSTER~g" deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml
     # deploy hub and spoke via OLM
     make cluster-ip

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.4
+	github.com/hashicorp/go-version v1.3.0
 	github.com/oklog/run v1.1.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
@@ -25,6 +26,7 @@ require (
 	github.com/prometheus-community/prom-label-proxy v0.3.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.48.1
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.47.1
+	github.com/prometheus/alertmanager v0.21.1-0.20201106142418-c39b78780054
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0
@@ -113,7 +115,6 @@ require (
 	github.com/openshift/library-go v0.0.0-20210609150209-1c980926414c // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/alertmanager v0.21.1-0.20201106142418-c39b78780054 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1227,6 +1227,7 @@ github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/operators/endpointmetrics/manifests/prometheus/kubernetes-monitoring-alertingrules.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/kubernetes-monitoring-alertingrules.yaml
@@ -7,6 +7,21 @@ metadata:
 data:
   kubernetes-monitoring-alertingrules.yaml: |
     groups:
+    - name: general-rules
+      rules:
+      - alert: Watchdog
+        annotations:
+          description: |
+            This is an alert meant to ensure that the entire alerting pipeline is functional.
+            This alert is always firing, therefore it should always be firing in Alertmanager
+            and always fire against a receiver. There are integrations with various notification
+            mechanisms that send a notification when this alert is not firing. For example the
+            "DeadMansSnitch" integration in PagerDuty.
+          summary: An alert that should always be firing to certify that Alertmanager
+            is working properly.
+        expr: vector(1)
+        labels:
+          severity: none
     - name: kube-state-metrics
       rules:
       - alert: KubeStateMetricsListErrors

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -247,7 +246,7 @@ var _ = Describe("Observability:", func() {
 		klog.V(3).Infof("Successfully deleted CM: thanos-ruler-custom-rules")
 	})
 
-	It("[P2][Sev2][Observability][Integration] Should have alert named Watchdog forwarded to alertmanager generated (alert/g0)", func() {
+	It("[P2][Sev2][Observability][Integration] Should have alert named Watchdog forwarded to alertmanager (alert/g0)", func() {
 		amURL := url.URL{
 			Scheme: "https",
 			Host:   "alertmanager-open-cluster-management-observability.apps." + testOptions.HubCluster.BaseDomain,
@@ -257,14 +256,9 @@ var _ = Describe("Observability:", func() {
 		q.Set("filter", "alertname=Watchdog")
 		amURL.RawQuery = q.Encode()
 
-		caCrt, err := utils.GetRouterCA(hubClient)
-		Expect(err).NotTo(HaveOccurred())
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(caCrt)
-
 		client := &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{RootCAs: pool},
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // skip CA verify because CA secret not found in KinD env.
 			},
 		}
 

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Observability:", func() {
 		klog.V(3).Infof("Successfully deleted CM: thanos-ruler-custom-rules")
 	})
 
-	It("[P2][Sev2][Observability][Stable] Should have alert named Watchdog forwarded to alertmanager generated (alert/g0)", func() {
+	It("[P2][Sev2][Observability][Integration] Should have alert named Watchdog forwarded to alertmanager generated (alert/g0)", func() {
 		amURL := url.URL{
 			Scheme: "https",
 			Host:   "alertmanager-open-cluster-management-observability.apps." + testOptions.HubCluster.BaseDomain,

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -5,12 +5,22 @@ package tests
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"reflect"
+	"sort"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/prometheus/alertmanager/api/v2/models"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 
@@ -235,6 +245,83 @@ var _ = Describe("Observability:", func() {
 		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
 
 		klog.V(3).Infof("Successfully deleted CM: thanos-ruler-custom-rules")
+	})
+
+	It("[P2][Sev2][Observability][Stable] Should have alert named Watchdog forwarded to alertmanager generated (alert/g0)", func() {
+		amURL := url.URL{
+			Scheme: "https",
+			Host:   "alertmanager-open-cluster-management-observability.apps." + testOptions.HubCluster.BaseDomain,
+			Path:   "/api/v2/alerts",
+		}
+		q := amURL.Query()
+		q.Set("filter", "alertname=Watchdog")
+		amURL.RawQuery = q.Encode()
+
+		caCrt, err := utils.GetRouterCA(hubClient)
+		Expect(err).NotTo(HaveOccurred())
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(caCrt)
+
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: pool},
+			},
+		}
+
+		alertGetReq, err := http.NewRequest("GET", amURL.String(), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		if os.Getenv("IS_KIND_ENV") != "true" {
+			alertGetReq.Header.Set("Authorization", "Bearer "+BearerToken)
+		}
+
+		expectedClusterIDs, err := utils.ListOCPManagedClusterIDs(testOptions, "4.8.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking Watchdog alerts are forwarded to the hub")
+		Eventually(func() error {
+			resp, err := client.Do(alertGetReq)
+			if err != nil {
+				klog.Errorf("err: %+v\n", err)
+				return err
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				klog.Errorf("err: %+v\n", resp)
+				return fmt.Errorf("Failed to get alerts via alertmanager route with http reponse: %v", resp)
+			}
+
+			alertResult, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+
+			postableAlerts := models.PostableAlerts{}
+			err = json.Unmarshal(alertResult, &postableAlerts)
+			if err != nil {
+				return err
+			}
+
+			clusterIDsInAlerts := []string{}
+			for _, alt := range postableAlerts {
+				if alt.Labels != nil {
+					labelSets := map[string]string(alt.Labels)
+					clusterID := labelSets["cluster"]
+					if clusterID != "" {
+						clusterIDsInAlerts = append(clusterIDsInAlerts, clusterID)
+					}
+				}
+			}
+
+			sort.Strings(clusterIDsInAlerts)
+			sort.Strings(expectedClusterIDs)
+			if !reflect.DeepEqual(clusterIDsInAlerts, expectedClusterIDs) {
+				return fmt.Errorf("Not all openshift managedclusters >=4.8.0 forward Watchdog alert to hub cluster")
+			}
+
+			return nil
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	JustAfterEach(func() {

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -54,7 +54,7 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok {
 				obsControllerStr = obsController.(string)
 			}
-			if obsControllerStr == "available" {
+			if obsControllerStr != "unreachable" {
 				clusterNames = append(clusterNames, name)
 			}
 		}
@@ -134,7 +134,7 @@ func ListKSManagedClusterNames(opt TestOptions) ([]string, error) {
 			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok {
 				obsControllerStr = obsController.(string)
 			}
-			if vendorStr != "OpenShift" && obsControllerStr == "available" {
+			if vendorStr != "OpenShift" && obsControllerStr != "unreachable" {
 				clusterNameStr := ""
 				if clusterNameVal, ok := labels["name"]; ok {
 					clusterNameStr = clusterNameVal.(string)

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	goversion "github.com/hashicorp/go-version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -70,4 +71,52 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 	}
 
 	return clusterNames, nil
+}
+
+func ListOCPManagedClusterIDs(opt TestOptions, minVersionStr string) ([]string, error) {
+	minVersion, err := goversion.NewVersion(minVersionStr)
+	if err != nil {
+		return nil, err
+	}
+	clientDynamic := GetKubeClientDynamic(opt, true)
+	objs, err := clientDynamic.Resource(NewOCMManagedClustersGVR()).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	clusterIDs := []string{}
+	for _, obj := range objs.Items {
+		metadata := obj.Object["metadata"].(map[string]interface{})
+		labels := metadata["labels"].(map[string]interface{})
+		if labels != nil {
+			vendorStr := ""
+			if vendor, ok := labels["vendor"]; ok {
+				vendorStr = vendor.(string)
+			}
+			obsControllerStr := ""
+			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok {
+				obsControllerStr = obsController.(string)
+			}
+			if vendorStr == "OpenShift" && obsControllerStr == "available" {
+				clusterVersionStr := ""
+				if clusterVersionVal, ok := labels["openshiftVersion"]; ok {
+					clusterVersionStr = clusterVersionVal.(string)
+				}
+				clusterVersion, err := goversion.NewVersion(clusterVersionStr)
+				if err != nil {
+					return nil, err
+				}
+				if clusterVersion.GreaterThanOrEqual(minVersion) {
+					clusterIDStr := ""
+					if clusterID, ok := labels["clusterID"]; ok {
+						clusterIDStr = clusterID.(string)
+					}
+					if len(clusterIDStr) > 0 {
+						clusterIDs = append(clusterIDs, clusterIDStr)
+					}
+				}
+			}
+		}
+	}
+
+	return clusterIDs, nil
 }

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -50,18 +50,12 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 		name := metadata["name"].(string)
 		labels := metadata["labels"].(map[string]interface{})
 		if labels != nil {
-			vendorStr := ""
-			if vendor, ok := labels["vendor"]; ok {
-				vendorStr = vendor.(string)
-			}
 			obsControllerStr := ""
 			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok {
 				obsControllerStr = obsController.(string)
 			}
-			if vendorStr == "OpenShift" || vendorStr == "GKE" || vendorStr == "EKS" || vendorStr == "AKS" {
-				if obsControllerStr != "unreachable" {
-					clusterNames = append(clusterNames, name)
-				}
+			if obsControllerStr == "available" {
+				clusterNames = append(clusterNames, name)
 			}
 		}
 	}
@@ -140,7 +134,7 @@ func ListKSManagedClusterNames(opt TestOptions) ([]string, error) {
 			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok {
 				obsControllerStr = obsController.(string)
 			}
-			if (vendorStr == "GKE" || vendorStr == "EKS" || vendorStr == "AKS") && obsControllerStr == "available" {
+			if vendorStr != "OpenShift" && obsControllerStr == "available" {
 				clusterNameStr := ""
 				if clusterNameVal, ok := labels["name"]; ok {
 					clusterNameStr = clusterNameVal.(string)


### PR DESCRIPTION
Add e2e case for alert forward from openshift clusters, by checking the `Watchdog` alert are forwarded to the hub, because `Watchdog` alert is always triggered, it is used to make sure the alert trigger is working. 

For *KS, add `Watchdog` alertrule to make sure the entire alerting pipeline is functional.

Signed-off-by: morvencao <lcao@redhat.com>