### PR TITLE
fix managed cluster labels in KinD env.

### DIFF
--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -134,7 +134,7 @@ func ListKSManagedClusterNames(opt TestOptions) ([]string, error) {
 			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok {
 				obsControllerStr = obsController.(string)
 			}
-			if vendorStr != "OpenShift" && obsControllerStr != "unreachable" {
+			if vendorStr != "OpenShift" && obsControllerStr == "available" {
 				clusterNameStr := ""
 				if clusterNameVal, ok := labels["name"]; ok {
 					clusterNameStr = clusterNameVal.(string)


### PR DESCRIPTION
This PR addresses the issue left from: https://github.com/open-cluster-management/multicluster-observability-operator/pull/819#issuecomment-966776031

Make sure the SF core component are using latest images so that we have the addon labels for managedclusters.


Signed-off-by: morvencao <lcao@redhat.com>