### PR TITLE
fix gke auth error

### DIFF
--- a/tests/pkg/utils/utils.go
+++ b/tests/pkg/utils/utils.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+        _ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
Run our e2e with GKE managedclusters. we met the following error:
```
•! Panic [30.709 seconds]
Observability:
/share/git/multicluster-observability-operator/tests/pkg/tests/observability_certrenew_test.go:17
  [P1][Sev1][Observability][Integration] Should have metrics collector pod restart if cert secret re-generated (ssli/g0) [It]
  /share/git/multicluster-observability-operator/tests/pkg/tests/observability_certrenew_test.go:30

  Test Panicked
  no Auth Provider found for name "gcp"
  /share/git/multicluster-observability-operator/tests/pkg/utils/utils.go:65

  Full Stack Trace
  github.com/open-cluster-management/multicluster-observability-operator/tests/pkg/utils.NewKubeClient({0xc000160258, 0x15}, {0xc000160288, 0x17}, {0x0, 0x0})
```
Signed-off-by: Song Song Li <ssli@redhat.com>