### PR TITLE
add retry during cert rotation if ca secret update failed

### DIFF
--- a/operators/multiclusterobservability/pkg/certificates/cert_controller.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller.go
@@ -190,8 +190,10 @@ func onDelete(c client.Client) func(obj interface{}) {
 						err = c.Update(context.TODO(), caSecret)
 						if err != nil {
 							log.Error(err, "Failed to update secret for ca certificate", "name", s.Name)
+							i++
+						} else {
+							break
 						}
-						break
 					} else {
 						// wait mco operator recreate the ca certificate at most 30 seconds
 						if i < 6 {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/18289
Signed-off-by: Marco llan@redhat.com