### PR TITLE
[release-2.3] fix stopCheckReady receive signal hang for status update.

### DIFF
--- a/controllers/multiclusterobservability/multiclusterobservability_status.go
+++ b/controllers/multiclusterobservability/multiclusterobservability_status.go
@@ -39,19 +39,22 @@ func StartStatusUpdate(c client.Client, instance *mcov1beta2.MultiClusterObserva
 				select {
 				case <-stopStatusUpdate:
 					updateStatusIsRunnning = false
-					stopCheckReady <- struct{}{}
+					close(stopCheckReady)
 					log.V(1).Info("status update goroutine is stopped.")
 					return
 				case <-requeueStatusUpdate:
 					log.V(1).Info("status update goroutine is triggered.")
 					updateStatus(c)
 					if updateReadyStatusIsRunnning && checkReadyStatus(c, instance) {
+						log.V(1).Info("send singal to stop status check ready goroutine because MCO status is ready")
 						stopCheckReady <- struct{}{}
 					}
 				}
 			}
 		}()
 		if !updateReadyStatusIsRunnning {
+			// init the stop ready check channel
+			stopCheckReady = make(chan struct{})
 			go func() {
 				updateReadyStatusIsRunnning = true
 				// defer close(stopCheckReady)


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/18418
cherrypick: https://github.com/open-cluster-management/multicluster-observability-operator/pull/733 to release-2.3

Signed-off-by: morvencao <lcao@redhat.com>